### PR TITLE
feat: trust score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-03-18
+
+### Added
+- **Trust Scores**: Introduced numeric data quality evaluation (`trust_score`) on the `KestEntry` model.
+- **Dynamic Trust Propagators**: Added `trust_score_updater` to the `@kest_verified` decorator, allowing node-specific synthesis of parent trust scores (e.g. upgrades/degrades via custom lambda functions). Defaults to propagating the lowest (minimum) trust score from the parents.
+- **Policy Enforcement**: Integrated `trust_score` directly into the OPA payload context to allow dynamic runtime blocking on minimum trust thresholds.
+- **Trust Origination**: Added `trust_score` parameter to the `originate` helper function to jump-start external data with specific trust baselines.
+
 ## [0.1.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 - **Data Lineage as a DAG**: Every execution step is recorded in a Directed Acyclic Graph (DAG) for non-repudiable audit trails.
 - **Taint Tracking**: Data is automatically marked with "taints" as it flows through untrusted or sensitive processing nodes.
-- **OPA Policy Enforcement**: Native integration with Open Policy Agent (Rego) to enforce security constraints at runtime based on the data's entire history.
+- **Trust Scores**: Numeric data quality indicators propagate alongside data, dynamically updating at processing boundaries via `trust_score_updater` lambdas.
+- **OPA Policy Enforcement**: Native integration with Open Policy Agent (Rego) to enforce security constraints at runtime based on the data's entire history and current trust score.
 - **Implicit Tracking**: Secure-by-default behavior. Any data crossing a `@verified` boundary is automatically tracked, even if it enters the system as a raw primitive.
 - **Cryptographic Integrity**: Recursive DAG hashing ($H_{bind}$) ensures that any modification to historical data or node identities invalidates the final signature.
 
@@ -138,8 +139,32 @@ For data entering from external or untrusted sources, use `originate` to define 
 data = originate(
     {"raw": "payload"},
     taint=["untrusted_source"],
-    labels={"env": "prod"}
+    labels={"env": "prod"},
+    trust_score=0.4
 )
+```
+
+### 3. Trust Scores & Validation
+
+In addition to discrete taints, Kest models data quality dynamically using Trust Scores. A function can specify exactly how it modifies the running trust score of the DAG pipeline by assigning a lambda to `trust_score_updater`.
+
+```python
+# Upgrades the maximum trust score of all parents by 0.3
+@verified(trust_score_updater=lambda scores: max(scores) + 0.3 if scores else 0.8)
+def validate_and_clean(data: dict) -> dict:
+    cleaned = data.copy()
+    cleaned["validated"] = True
+    return cleaned
+```
+
+By default (if no updater is provided), Kest inherently propagates the **minimum** trust score of all parents, guaranteeing that combining dirty data with clean data results in dirty data, unless explicitly washed and upgraded.
+
+Policies can then easily block low-fidelity data:
+
+```rego
+allow {
+    input.trust_score >= 0.70
+}
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -148,16 +148,20 @@ data = originate(
 
 In addition to discrete taints, Kest models data quality dynamically using Trust Scores. A function can specify exactly how it modifies the running trust score of the DAG pipeline by assigning a lambda to `trust_score_updater`.
 
+By default, every computation node has an inherent `node_trust_score` of 1.0 (perfectly trusted). If no `trust_score_updater` is defined, the output data is assigned the minimum trust score of ALL parents AND the node itself (`min([node_trust_score] + parent_trust_scores)`). This guarantees that dirty data remains dirty, and untrusted nodes taint clean data.
+
 ```python
-# Upgrades the maximum trust score of all parents by 0.3
-@verified(trust_score_updater=lambda scores: max(scores) + 0.3 if scores else 0.8)
+# The validation process is highly trusted (0.9), and specifically 
+# upgrades the maximum trust score of all parents by 0.3
+@verified(
+    node_trust_score=0.9, 
+    trust_score_updater=lambda node, parents: max([node] + parents) + 0.3 if parents else node
+)
 def validate_and_clean(data: dict) -> dict:
     cleaned = data.copy()
     cleaned["validated"] = True
     return cleaned
 ```
-
-By default (if no updater is provided), Kest inherently propagates the **minimum** trust score of all parents, guaranteeing that combining dirty data with clean data results in dirty data, unless explicitly washed and upgraded.
 
 Policies can then easily block low-fidelity data:
 

--- a/examples/trust_score_demo.ipynb
+++ b/examples/trust_score_demo.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@verified(trust_score_updater=lambda scores: max(scores) + 0.3 if scores else 0.8)\n",
+    "@verified(trust_score_updater=node_trust_score=0.8, trust_score_updater=lambda node, parents: max([node] + parents) + 0.3 if parents else node)\n",
     "def validate_and_clean(data: dict) -> dict:\n",
     "    print(\"-> Cleaning and validating data. Trust score upgrading...\")\n",
     "    cleaned = data.copy()\n",

--- a/examples/trust_score_demo.ipynb
+++ b/examples/trust_score_demo.ipynb
@@ -18,10 +18,12 @@
    "outputs": [],
    "source": [
     "from kest import config, originate, verified\n",
-    "from kest.core.policy import LocalOpaEngine, _HAS_REGORUS\n",
+    "from kest.core.policy import _HAS_REGORUS, LocalOpaEngine\n",
     "\n",
     "if not _HAS_REGORUS:\n",
-    "    print(\"Error: lakera-regorus is not installed. Please install 'kest[opa]' on Python 3.11.\")\n",
+    "    print(\n",
+    "        \"Error: lakera-regorus is not installed. Please install 'kest[opa]' on Python 3.11.\"\n",
+    "    )\n",
     "\n",
     "config.policy_engine = LocalOpaEngine()\n",
     "policy = \"\"\"\n",
@@ -52,12 +54,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@verified(trust_score_updater=node_trust_score=0.8, trust_score_updater=lambda node, parents: max([node] + parents) + 0.3 if parents else node)\n",
+    "@verified(\n",
+    "    node_trust_score=0.8,\n",
+    "    trust_score_updater=lambda node, parents: (\n",
+    "        max([node] + parents) + 0.3 if parents else node\n",
+    "    ),\n",
+    ")\n",
     "def validate_and_clean(data: dict) -> dict:\n",
     "    print(\"-> Cleaning and validating data. Trust score upgrading...\")\n",
     "    cleaned = data.copy()\n",
     "    cleaned[\"validated\"] = True\n",
     "    return cleaned\n",
+    "\n",
     "\n",
     "@verified(enforce_rules=[\"data.kest.trust.allow\"])\n",
     "def generate_report(data: dict) -> dict:\n",
@@ -118,7 +126,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -132,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/examples/trust_score_demo.ipynb
+++ b/examples/trust_score_demo.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Trust Score Demo\n",
+    "\n",
+    "This notebook demonstrates how to implement and evaluate **data trust scores** using Kest. \n",
+    "\n",
+    "We will set up an OPA policy that enforces a minimum trust score threshold on data, establish data with varying trust labels originating from the internet, and show how trust scores can be manipulated during the lineage pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kest import config, originate, verified\n",
+    "from kest.core.policy import LocalOpaEngine, _HAS_REGORUS\n",
+    "\n",
+    "if not _HAS_REGORUS:\n",
+    "    print(\"Error: lakera-regorus is not installed. Please install 'kest[opa]' on Python 3.11.\")\n",
+    "\n",
+    "config.policy_engine = LocalOpaEngine()\n",
+    "policy = \"\"\"\n",
+    "package kest.trust\n",
+    "default allow = false\n",
+    "\n",
+    "allow {\n",
+    "    input.trust_score >= 0.70\n",
+    "}\n",
+    "\"\"\"\n",
+    "config.policy_engine.add_policy(\"trust_access\", policy)\n",
+    "print(\"Global OPA Engine instantiated with threshold >= 0.70\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Defining Verification Pipelines\n",
+    "\n",
+    "By default, `kest_verified` functions will inherently compute the **minimum** trust score of their parents when traversing lineages. \n",
+    "However, we can explicitly define custom `trust_score_updaters` for specific nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@verified(trust_score_updater=lambda scores: max(scores) + 0.3 if scores else 0.8)\n",
+    "def validate_and_clean(data: dict) -> dict:\n",
+    "    print(\"-> Cleaning and validating data. Trust score upgrading...\")\n",
+    "    cleaned = data.copy()\n",
+    "    cleaned[\"validated\"] = True\n",
+    "    return cleaned\n",
+    "\n",
+    "@verified(enforce_rules=[\"data.kest.trust.allow\"])\n",
+    "def generate_report(data: dict) -> dict:\n",
+    "    print(f\"-> Successfully generated report from high-trust data: {data}\")\n",
+    "    return {\"report_generated\": True, \"data\": data}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scenario 1: Processing Without Validation (Blocked)\n",
+    "\n",
+    "If we take raw untrustworthy data and route it straight into a secured endpoint, it should fail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Our data entered the system with a modest trust score of 0.5\n",
+    "raw_data = originate({\"source\": \"website\", \"content\": \"raw_user_data\"}, trust_score=0.5)\n",
+    "\n",
+    "try:\n",
+    "    generate_report(raw_data)\n",
+    "except PermissionError as e:\n",
+    "    print(f\"\\n❌ Blocked Successfully! Reason: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scenario 2: With Validation (Allowed)\n",
+    "\n",
+    "If we run the data through our `validate_and_clean` pipeline, the trust score is dynamically augmented across the DAG, enabling it to hit the necessary reporting threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_data = validate_and_clean(raw_data)\n",
+    "\n",
+    "# Output will be allowed, and history tracked\n",
+    "report = generate_report(clean_data)\n",
+    "\n",
+    "leaf_id = list(report.passport.history.keys())[-1]\n",
+    "final_score = report.passport.history[leaf_id].trust_score\n",
+    "\n",
+    "print(f\"\\n✅ Report Generated! Final Trusted DAG Node Score: {final_score}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/trust_score_demo.py
+++ b/examples/trust_score_demo.py
@@ -1,0 +1,69 @@
+from kest import config, originate, verified
+from kest.core.policy import _HAS_REGORUS, LocalOpaEngine
+
+
+def run_demo():
+    if not _HAS_REGORUS:
+        print("Skipping demo since `lakera_regorus` is not installed.")
+        return
+
+    # Setup the Local OPA Engine
+    config.policy_engine = LocalOpaEngine()
+    policy = """
+package kest.trust
+default allow = false
+
+allow {
+    input.trust_score >= 0.70
+}
+"""
+    config.policy_engine.add_policy("trust_access", policy)
+
+    # Define our processing nodes
+    @verified(trust_score_updater=lambda scores: min(scores) if scores else 0.5)
+    def fetch_data(source: str) -> dict:
+        print(f"-> Fetching raw data from {source}...")
+        return {"source": source, "content": "raw_user_data"}
+
+    @verified(trust_score_updater=lambda scores: max(scores) + 0.3 if scores else 0.8)
+    def validate_and_clean(data: dict) -> dict:
+        print("-> Cleaning and validating data. Trust score upgrading...")
+        cleaned = data.copy()
+        cleaned["validated"] = True
+        return cleaned
+
+    @verified(enforce_rules=["data.kest.trust.allow"])
+    def generate_report(data: dict) -> dict:
+        print(f"-> Successfully generated report from high-trust data: {data}")
+        return {"report_generated": True, "data": data}
+
+    print("--- Scenario 1: Insufficient Trust Blocked ---")
+    try:
+        raw_data = originate(
+            {"source": "website", "content": "raw_user_data"}, trust_score=0.5
+        )
+        # raw_data has a score of 0.5, which < 0.70.
+        generate_report(raw_data)
+    except PermissionError as e:
+        print(f"Expected PermissionError: {e}")
+
+    print("\n--- Scenario 2: Validated Trust Allowed ---")
+    try:
+        raw_data = originate(
+            {"source": "website", "content": "raw_user_data"}, trust_score=0.5
+        )
+        clean_data = validate_and_clean(raw_data)
+
+        # Current Trust Score should be 0.5 + 0.3 = 0.8
+        report = generate_report(clean_data)
+
+        assert report.passport is not None
+        leaf_id = list(report.passport.history.keys())[-1]
+        final_score = report.passport.history[leaf_id].trust_score
+        print(f"Final Trust Score: {final_score}")
+    except Exception as e:
+        print(f"Unexpected Exception: {e}")
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/trust_score_demo.py
+++ b/examples/trust_score_demo.py
@@ -20,12 +20,22 @@ allow {
     config.policy_engine.add_policy("trust_access", policy)
 
     # Define our processing nodes
-    @verified(trust_score_updater=lambda scores: min(scores) if scores else 0.5)
+    @verified(
+        node_trust_score=0.9,
+        trust_score_updater=lambda node, parents: (
+            min([node] + parents) if parents else node
+        ),
+    )
     def fetch_data(source: str) -> dict:
         print(f"-> Fetching raw data from {source}...")
         return {"source": source, "content": "raw_user_data"}
 
-    @verified(trust_score_updater=lambda scores: max(scores) + 0.3 if scores else 0.8)
+    @verified(
+        node_trust_score=0.8,
+        trust_score_updater=lambda node, parents: (
+            max([node] + parents) + 0.3 if parents else node
+        ),
+    )
     def validate_and_clean(data: dict) -> dict:
         print("-> Cleaning and validating data. Trust score upgrading...")
         cleaned = data.copy()
@@ -54,7 +64,7 @@ allow {
         )
         clean_data = validate_and_clean(raw_data)
 
-        # Current Trust Score should be 0.5 + 0.3 = 0.8
+        # Current Trust Score should be max(0.8, 0.5) + 0.3 = 1.1
         report = generate_report(clean_data)
 
         assert report.passport is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kest"
-version = "0.1.0"
+version = "0.2.0"
 description = "Attested Data Lineage specification and reference implementation"
 authors = [
   { name = "Eterna2", email = "eterna2net@gmail.com" },

--- a/src/kest/core/helpers.py
+++ b/src/kest/core/helpers.py
@@ -20,7 +20,7 @@ def originate(
     policy_refs: Optional[List[str]] = None,
     taint: Optional[List[str]] = None,
     labels: Optional[Dict[str, str]] = None,
-    trust_score: float = 0.0,
+    trust_score: float = 1.0,
 ) -> KestData[T]:
     """
     Wraps raw data in a KestData struct and initializes the Passport DAG lineage.

--- a/src/kest/core/helpers.py
+++ b/src/kest/core/helpers.py
@@ -20,6 +20,7 @@ def originate(
     policy_refs: Optional[List[str]] = None,
     taint: Optional[List[str]] = None,
     labels: Optional[Dict[str, str]] = None,
+    trust_score: float = 0.0,
 ) -> KestData[T]:
     """
     Wraps raw data in a KestData struct and initializes the Passport DAG lineage.
@@ -47,6 +48,7 @@ def originate(
         labels=labels or {},
         added_taint=initial_taint.copy(),
         accumulated_taint=initial_taint.copy(),
+        trust_score=trust_score,
     )
     passport.history[entry_id] = entry
 

--- a/src/kest/core/models.py
+++ b/src/kest/core/models.py
@@ -16,6 +16,7 @@ class KestEntry(BaseModel):
     labels: Dict[str, str] = Field(default_factory=dict)
     added_taint: List[str] = Field(default_factory=list)
     accumulated_taint: List[str] = Field(default_factory=list)
+    trust_score: float = Field(default=0.0)
 
 
 class PassportOriginPolicies(BaseModel):

--- a/src/kest/core/models.py
+++ b/src/kest/core/models.py
@@ -16,7 +16,7 @@ class KestEntry(BaseModel):
     labels: Dict[str, str] = Field(default_factory=dict)
     added_taint: List[str] = Field(default_factory=list)
     accumulated_taint: List[str] = Field(default_factory=list)
-    trust_score: float = Field(default=0.0)
+    trust_score: float = Field(default=1.0)
 
 
 class PassportOriginPolicies(BaseModel):

--- a/src/kest/presentation/decorators.py
+++ b/src/kest/presentation/decorators.py
@@ -24,7 +24,8 @@ def kest_verified(
     added_taint: Optional[List[str]] = None,
     env_collectors: Optional[List[EnvironmentCollector]] = None,
     telemetry_exporters: Optional[List[TelemetryExporter]] = None,
-    trust_score_updater: Optional[Callable[[List[float]], float]] = None,
+    node_trust_score: float = 1.0,
+    trust_score_updater: Optional[Callable[[float, List[float]], float]] = None,
     logger: Optional[logging.Logger] = None,
 ) -> Callable[[Callable[..., R]], Callable[..., KestData[R]]]:
     """
@@ -132,12 +133,11 @@ def kest_verified(
 
             # Trust Score Synthesis
             if trust_score_updater:
-                current_trust_score = trust_score_updater(parent_trust_scores)
+                current_trust_score = trust_score_updater(
+                    node_trust_score, parent_trust_scores
+                )
             else:
-                if parent_trust_scores:
-                    current_trust_score = min(parent_trust_scores)
-                else:
-                    current_trust_score = 0.0
+                current_trust_score = min([node_trust_score] + parent_trust_scores)
 
             import typing
 

--- a/src/kest/presentation/decorators.py
+++ b/src/kest/presentation/decorators.py
@@ -24,6 +24,7 @@ def kest_verified(
     added_taint: Optional[List[str]] = None,
     env_collectors: Optional[List[EnvironmentCollector]] = None,
     telemetry_exporters: Optional[List[TelemetryExporter]] = None,
+    trust_score_updater: Optional[Callable[[List[float]], float]] = None,
     logger: Optional[logging.Logger] = None,
 ) -> Callable[[Callable[..., R]], Callable[..., KestData[R]]]:
     """
@@ -79,6 +80,7 @@ def kest_verified(
             parent_accumulated_taints = []
             parent_ids = []
             parent_hashes = []
+            parent_trust_scores = []
 
             # We need a base passport to merge into. Pick the first one found, or create implicit.
             passport = None
@@ -117,6 +119,7 @@ def kest_verified(
                 parent_ids.append(p_id)
                 parent_hashes.append(p_entry.content_hash)
                 parent_accumulated_taints.extend(p_entry.accumulated_taint)
+                parent_trust_scores.append(p_entry.trust_score)
 
                 # Merge history branches
                 if w.passport != passport:
@@ -126,6 +129,15 @@ def kest_verified(
 
             # Current node's taints: union of parent accumulated taints + explicitly added taints
             current_tag_accumulated = list(set(parent_accumulated_taints + added_taint))
+
+            # Trust Score Synthesis
+            if trust_score_updater:
+                current_trust_score = trust_score_updater(parent_trust_scores)
+            else:
+                if parent_trust_scores:
+                    current_trust_score = min(parent_trust_scores)
+                else:
+                    current_trust_score = 0.0
 
             import typing
 
@@ -163,6 +175,7 @@ def kest_verified(
                     "policy_refs": (
                         passport.origin.policies.curated_refs if passport.origin else []
                     ),
+                    "trust_score": current_trust_score,
                 }
                 if logger:
                     logger.debug(
@@ -191,6 +204,7 @@ def kest_verified(
                 environment=env_data,
                 added_taint=added_taint,
                 accumulated_taint=current_tag_accumulated,
+                trust_score=current_trust_score,
             )
             passport.history[entry_id] = entry
 

--- a/test_debug.py
+++ b/test_debug.py
@@ -1,0 +1,6 @@
+from kest.core.policy import _HAS_REGORUS
+
+if _HAS_REGORUS:
+    import tests.flow_test as flow
+
+    flow.test_happy_path_pii_stripped_and_internet_merging_allowed()

--- a/tests/flow_test.py
+++ b/tests/flow_test.py
@@ -3,10 +3,14 @@ import pytest
 from kest import config, originate, verified
 from kest.core.policy import _HAS_REGORUS, LocalOpaEngine
 
-# Setup the Global Policy Engine for testing
-if _HAS_REGORUS:
-    config.policy_engine = LocalOpaEngine()
-    policy = """
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_policy():
+    if _HAS_REGORUS:
+        engine = LocalOpaEngine()
+        config.policy_engine = engine
+
+        policy = """
 package kest.policy
 default allow = false
 
@@ -24,7 +28,7 @@ has_pii { input.taints[_] == "pii_data" }
 has_internet { input.taints[_] == "internet_data" }
 has_stripped { input.taints[_] == "pii_stripped" }
 """
-    config.policy_engine.add_policy("data_access", policy)
+        engine.add_policy("data_access", policy)
 
 
 # Shared Mock verified functions

--- a/tests/trust_score_test.py
+++ b/tests/trust_score_test.py
@@ -22,7 +22,12 @@ def process_data(data: dict) -> dict:
     return data
 
 
-@verified(trust_score_updater=lambda scores: max(scores) + 0.2 if scores else 0.8)
+@verified(
+    node_trust_score=0.9,
+    trust_score_updater=lambda node_score, parent_scores: (
+        max([node_score] + parent_scores) + 0.2 if parent_scores else node_score
+    ),
+)
 def upgrade_trust(data: dict) -> dict:
     return data
 
@@ -59,11 +64,11 @@ def test_trust_score_upgrades():
     # Upgrade the trust score
     upgraded = upgrade_trust(low_trust_data)
 
-    # 0.4 + 0.2 = 0.6
+    # max([0.9, 0.4]) + 0.2 = 1.1
     assert upgraded.passport is not None
     leaf_entry_id = list(upgraded.passport.history.keys())[-1]
     # Use pytest.approx due to float math
-    assert upgraded.passport.history[leaf_entry_id].trust_score == pytest.approx(0.6)
+    assert upgraded.passport.history[leaf_entry_id].trust_score == pytest.approx(1.1)
 
     # Attempt to sink it (should succeed because 0.6 >= 0.5)
     result = high_trust_sink(upgraded)
@@ -71,11 +76,11 @@ def test_trust_score_upgrades():
 
 
 def test_trust_score_default_propagation_multiple_parents():
-    # Test min logic without OPA enforcement (just testing the decorator synthesis)
+    # Test min logic without OPA enforcement
     d1 = originate({"a": 1}, trust_score=0.9)
     d2 = originate({"b": 2}, trust_score=0.3)
 
-    @verified()
+    @verified(node_trust_score=0.8)
     def merge(a: dict, b: dict) -> dict:
         return {"merged": True}
 
@@ -83,5 +88,5 @@ def test_trust_score_default_propagation_multiple_parents():
     assert res.passport is not None
     leaf_entry_id = list(res.passport.history.keys())[-1]
 
-    # Needs to be min(0.9, 0.3) = 0.3
+    # Needs to be min([0.8, 0.9, 0.3]) = 0.3
     assert res.passport.history[leaf_entry_id].trust_score == 0.3

--- a/tests/trust_score_test.py
+++ b/tests/trust_score_test.py
@@ -1,0 +1,87 @@
+import pytest
+
+from kest import config, originate, verified
+from kest.core.policy import _HAS_REGORUS, LocalOpaEngine
+
+# Setup the Global Policy Engine for testing
+if _HAS_REGORUS:
+    config.policy_engine = LocalOpaEngine()
+    policy = """
+package kest.trust
+default allow = false
+
+allow {
+    input.trust_score >= 0.5
+}
+"""
+    config.policy_engine.add_policy("trust_access", policy)
+
+
+@verified()
+def process_data(data: dict) -> dict:
+    return data
+
+
+@verified(trust_score_updater=lambda scores: max(scores) + 0.2 if scores else 0.8)
+def upgrade_trust(data: dict) -> dict:
+    return data
+
+
+@verified(enforce_rules=["data.kest.trust.allow"])
+def high_trust_sink(data: dict) -> dict:
+    return data
+
+
+@pytest.mark.skipif(not _HAS_REGORUS, reason="lakera-regorus requires Python 3.11")
+def test_trust_score_blocks_low_quality():
+    # Originate data with a low trust score
+    low_trust_data = originate({"content": "suspicious"}, trust_score=0.2)
+
+    # Process it normally, score should propagate as 0.2 (min of parents)
+    processed = process_data(low_trust_data)
+    assert processed.passport is not None
+    leaf_entry_id = list(processed.passport.history.keys())[-1]
+    assert processed.passport.history[leaf_entry_id].trust_score == 0.2
+
+    # Attempt to sink it (should fail because 0.2 < 0.5)
+    with pytest.raises(
+        PermissionError,
+        match="Kest Policy Violation: Execution blocked by rule 'data.kest.trust.allow'",
+    ):
+        high_trust_sink(processed)
+
+
+@pytest.mark.skipif(not _HAS_REGORUS, reason="lakera-regorus requires Python 3.11")
+def test_trust_score_upgrades():
+    # Originate data with a low trust score
+    low_trust_data = originate({"content": "suspicious"}, trust_score=0.4)
+
+    # Upgrade the trust score
+    upgraded = upgrade_trust(low_trust_data)
+
+    # 0.4 + 0.2 = 0.6
+    assert upgraded.passport is not None
+    leaf_entry_id = list(upgraded.passport.history.keys())[-1]
+    # Use pytest.approx due to float math
+    assert upgraded.passport.history[leaf_entry_id].trust_score == pytest.approx(0.6)
+
+    # Attempt to sink it (should succeed because 0.6 >= 0.5)
+    result = high_trust_sink(upgraded)
+    assert result.data["content"] == "suspicious"
+
+
+def test_trust_score_default_propagation_multiple_parents():
+    # Test min logic without OPA enforcement (just testing the decorator synthesis)
+    d1 = originate({"a": 1}, trust_score=0.9)
+    d2 = originate({"b": 2}, trust_score=0.3)
+
+    @verified()
+    def merge(a: dict, b: dict) -> dict:
+        return {"merged": True}
+
+    res = merge(d1, d2)
+    assert res.passport is not None
+    leaf_entry_id = list(res.passport.history.keys())[-1]
+
+    # Needs to be min(0.9, 0.3) = 0.3
+    assert res.passport.history[leaf_entry_id].trust_score == 0.3

--- a/tests/trust_score_test.py
+++ b/tests/trust_score_test.py
@@ -3,10 +3,14 @@ import pytest
 from kest import config, originate, verified
 from kest.core.policy import _HAS_REGORUS, LocalOpaEngine
 
-# Setup the Global Policy Engine for testing
-if _HAS_REGORUS:
-    config.policy_engine = LocalOpaEngine()
-    policy = """
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_policy():
+    if _HAS_REGORUS:
+        engine = LocalOpaEngine()
+        config.policy_engine = engine
+
+        policy = """
 package kest.trust
 default allow = false
 
@@ -14,7 +18,7 @@ allow {
     input.trust_score >= 0.5
 }
 """
-    config.policy_engine.add_policy("trust_access", policy)
+        engine.add_policy("trust_access", policy)
 
 
 @verified()

--- a/uv.lock
+++ b/uv.lock
@@ -1196,7 +1196,7 @@ wheels = [
 
 [[package]]
 name = "kest"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## [0.2.0] - 2026-03-18

### Added
- **Trust Scores**: Introduced numeric data quality evaluation (`trust_score`) on the `KestEntry` model.
- **Dynamic Trust Propagators**: Added `trust_score_updater` to the `@kest_verified` decorator, allowing node-specific synthesis of parent trust scores (e.g. upgrades/degrades via custom lambda functions). Defaults to propagating the lowest (minimum) trust score from the parents.
- **Policy Enforcement**: Integrated `trust_score` directly into the OPA payload context to allow dynamic runtime blocking on minimum trust thresholds.
- **Trust Origination**: Added `trust_score` parameter to the `originate` helper function to jump-start external data with specific trust baselines.