### PR TITLE
perf(kest-core): bound the signing thread pool in async_wrapper

### DIFF
--- a/libs/kest-core/python/python/kest/core/decorators.py
+++ b/libs/kest-core/python/python/kest/core/decorators.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import functools
 import hashlib
 import inspect
@@ -109,6 +110,43 @@ _POLICY_CACHE = _PolicyDecisionCache(
     maxsize=1024,
     ttl_seconds=float(os.getenv("KEST_POLICY_CACHE_TTL", "5.0")),
 )
+
+
+# ---------------------------------------------------------------------------
+# Fix 6: Bounded Signing Thread Pool
+# ---------------------------------------------------------------------------
+
+# Singleton executor for CPU-bound signing and packing work, shared across all @kest_verified calls.
+_SIGN_EXECUTOR: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_SIGN_EXECUTOR_LOCK = Lock()
+
+
+def _get_sign_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """
+    Get or create the bounded thread pool for signing operations.
+
+    Worker count defaults to min(4, cpu_count) but can be overridden via KEST_SIGN_WORKERS.
+    """
+    global _SIGN_EXECUTOR
+    if _SIGN_EXECUTOR is not None:
+        return _SIGN_EXECUTOR
+
+    with _SIGN_EXECUTOR_LOCK:
+        if _SIGN_EXECUTOR is None:
+            env_workers = os.getenv("KEST_SIGN_WORKERS")
+            if env_workers:
+                try:
+                    workers = int(env_workers)
+                except ValueError:
+                    workers = min(4, os.cpu_count() or 1)
+            else:
+                workers = min(4, os.cpu_count() or 1)
+
+            _SIGN_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                max_workers=workers,
+                thread_name_prefix="kest-sign",
+            )
+        return _SIGN_EXECUTOR
 
 
 def invalidate_policy_cache() -> None:
@@ -508,8 +546,11 @@ def kest_verified(
                     raise PermissionError(f"Kest policies {policies} denied execution")
 
                 # Fix 6: Offload CPU-bound signing + baggage packing to thread pool
-                # This unblocks the event loop during Ed25519/canonicalization work
-                new_ctx = await asyncio.to_thread(
+                # This unblocks the event loop during Ed25519/canonicalization work.
+                # We use a bounded executor to prevent thread exhaustion (SPEC A-01-I).
+                loop = asyncio.get_running_loop()
+                new_ctx = await loop.run_in_executor(
+                    _get_sign_executor(),
                     _execute_core_post_auth,
                     state,
                     func.__name__,

--- a/libs/kest-core/python/python/kest/core/executor_test.py
+++ b/libs/kest-core/python/python/kest/core/executor_test.py
@@ -1,0 +1,46 @@
+import os
+import concurrent.futures
+from unittest.mock import patch
+from kest.core.decorators import _get_sign_executor
+import kest.core.decorators
+
+def test_executor_singleton():
+    """Verify that _get_sign_executor returns the same instance across calls."""
+    exec1 = _get_sign_executor()
+    exec2 = _get_sign_executor()
+    assert exec1 is exec2
+    assert isinstance(exec1, concurrent.futures.ThreadPoolExecutor)
+    assert exec1._thread_name_prefix == "kest-sign"
+
+def test_executor_worker_count_default():
+    """Verify default worker count is min(4, cpu_count)."""
+    # Reset singleton for testing
+    with kest.core.decorators._SIGN_EXECUTOR_LOCK:
+        kest.core.decorators._SIGN_EXECUTOR = None
+
+    cpu_count = os.cpu_count() or 1
+    expected = min(4, cpu_count)
+
+    executor = _get_sign_executor()
+    assert executor._max_workers == expected
+
+def test_executor_worker_count_env_var():
+    """Verify worker count can be overridden via KEST_SIGN_WORKERS."""
+    # Reset singleton for testing
+    with kest.core.decorators._SIGN_EXECUTOR_LOCK:
+        kest.core.decorators._SIGN_EXECUTOR = None
+
+    with patch.dict(os.environ, {"KEST_SIGN_WORKERS": "10"}):
+        executor = _get_sign_executor()
+        assert executor._max_workers == 10
+
+def test_executor_invalid_env_var_fallback():
+    """Verify fallback to default if KEST_SIGN_WORKERS is invalid."""
+    # Reset singleton for testing
+    with kest.core.decorators._SIGN_EXECUTOR_LOCK:
+        kest.core.decorators._SIGN_EXECUTOR = None
+
+    with patch.dict(os.environ, {"KEST_SIGN_WORKERS": "not-a-number"}):
+        executor = _get_sign_executor()
+        cpu_count = os.cpu_count() or 1
+        assert executor._max_workers == min(4, cpu_count)


### PR DESCRIPTION
Replaces the unbounded asyncio.to_thread with a module-level bounded ThreadPoolExecutor for CPU-bound signing and baggage packing operations in the @kest_verified decorator. This prevents OS thread exhaustion under high concurrency. The pool size defaults to min(4, cpu_count) and is configurable via KEST_SIGN_WORKERS environment variable.

Fixes #10

---
*PR created automatically by Jules for task [3452011445409023685](https://jules.google.com/task/3452011445409023685) started by @eterna2*