### PR TITLE
perf(kest-core): optimize Passport cache invalidation and taint accumulation (A-03-I/II/III)

### DIFF
--- a/libs/kest-core/python/python/kest/core/decorators.py
+++ b/libs/kest-core/python/python/kest/core/decorators.py
@@ -314,7 +314,7 @@ def _execute_core_logic(
     current_node_trust = self_score if is_root else 100
 
     # Fix 1: Use cached passport properties instead of O(n) inline parsing
-    parent_taints: set = set()
+    parent_taints: frozenset = frozenset()
     if not is_root:
         parent_scores = passport.trust_scores
         parent_taints = passport.accumulated_taints
@@ -324,8 +324,8 @@ def _execute_core_logic(
     if trust_override is not None:
         current_node_trust = trust_override
 
-    # Calculate new accumulated taints
-    current_accumulated = parent_taints.copy()
+    # Calculate new accumulated taints (mutable copy for add/remove operations)
+    current_accumulated = set(parent_taints)
     if added_taints:
         current_accumulated.update(added_taints)
     if removed_taints:

--- a/libs/kest-core/python/python/kest/core/models.py
+++ b/libs/kest-core/python/python/kest/core/models.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, TypedDict
 
 
-@dataclass
+@dataclass(slots=True)
 class Passport:
     """
     Represents a verifiable execution graph (lineage).
@@ -20,14 +20,31 @@ class Passport:
 
     entries: List[str] = field(default_factory=list)
 
-    # --- Fix 1: parsed_entries cache ---
-    # Invalidated in add_signature() to stay consistent.
-    _entries_snapshot: List[str] = field(
-        default_factory=list, repr=False, compare=False
-    )
+    # --- A-03-I: version counter for O(1) cache invalidation ---
+    _version: int = field(default=0, repr=False, compare=False)
+    _cache_version: int = field(default=-1, repr=False, compare=False)
     _parsed_cache: Optional[List[Dict[str, Any]]] = field(
         default=None, repr=False, compare=False
     )
+
+    # --- A-03-II: incrementally-updated aggregate caches ---
+    _taints_cache: frozenset = field(
+        default_factory=frozenset, repr=False, compare=False
+    )
+    _min_trust_cache: int = field(default=100, repr=False, compare=False)
+
+    def __post_init__(self):
+        """Rebuild incremental caches from initial entries (handles merge, deserialize, direct construction)."""
+        if self.entries:
+            taints: set = set()
+            min_trust = 100
+            for entry in self.entries:
+                payload = self._decode_payload(entry)
+                taints.update(payload.get("taints", []))
+                min_trust = min(min_trust, payload.get("trust_score", 100))
+            self._taints_cache = frozenset(taints)
+            self._min_trust_cache = min_trust
+            self._version = len(self.entries)
 
     @staticmethod
     def _decode_payload(jws: str) -> Dict[str, Any]:
@@ -43,10 +60,10 @@ class Passport:
             return {}
 
     def _get_parsed_entries(self) -> List[Dict[str, Any]]:
-        """Return parsed passport payloads, rebuilding cache only when entries changed."""
-        if self._parsed_cache is None or self._entries_snapshot != self.entries:
+        """Return parsed passport payloads, rebuilding cache only when version changed."""
+        if self._parsed_cache is None or self._cache_version != self._version:
             self._parsed_cache = [self._decode_payload(e) for e in self.entries]
-            self._entries_snapshot = list(self.entries)
+            self._cache_version = self._version
         return self._parsed_cache
 
     @property
@@ -55,12 +72,14 @@ class Passport:
         return [e.get("trust_score", 0) for e in self._get_parsed_entries()]
 
     @property
-    def accumulated_taints(self) -> set:
-        """Return the union of taints across all passport entries (O(1) after first call)."""
-        taints: set = set()
-        for e in self._get_parsed_entries():
-            taints.update(e.get("taints", []))
-        return taints
+    def accumulated_taints(self) -> frozenset:
+        """Return the union of taints across all passport entries (O(1))."""
+        return self._taints_cache
+
+    @property
+    def min_trust_score(self) -> int:
+        """Return the minimum trust score across all entries (O(1))."""
+        return self._min_trust_cache
 
     @staticmethod
     def merge(*passports: "Passport") -> "Passport":
@@ -89,9 +108,15 @@ class Passport:
         Args:
             signature: The JWS-formatted audit entry string.
         """
+        payload = self._decode_payload(signature)
         self.entries.append(signature)
-        # Invalidate parse cache so next access re-parses
-        self._parsed_cache = None
+        # A-03-I: O(1) cache invalidation via version counter
+        self._version += 1
+        # A-03-II: O(1) incremental taint/trust aggregation
+        self._taints_cache = self._taints_cache | frozenset(payload.get("taints", []))
+        self._min_trust_cache = min(
+            self._min_trust_cache, payload.get("trust_score", 100)
+        )
 
     def serialize(self) -> str:
         """

--- a/libs/kest-core/python/python/kest/core/models_test.py
+++ b/libs/kest-core/python/python/kest/core/models_test.py
@@ -203,6 +203,116 @@ def test_passport_add_signature():
 
 
 # ===========================================================================
+# Passport Cache Optimization (A-03-I/II/III, Issue #12)
+# ===========================================================================
+
+
+def _make_jws(trust_score: int = 100, taints: list | None = None) -> str:
+    """Build a minimal valid JWS with the given trust_score and taints."""
+    payload: dict = {"trust_score": trust_score}
+    if taints:
+        payload["taints"] = taints
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    return f"h.{payload_b64}.s"
+
+
+def test_passport_version_counter_invalidation():
+    """A-03-I: Parsed cache uses O(1) integer version comparison, not O(n) list equality."""
+    p = Passport()
+    jws1 = _make_jws(trust_score=90, taints=["t1"])
+    p.add_signature(jws1)
+
+    # First read populates cache
+    _ = p.trust_scores
+    cache_after_first = p._parsed_cache
+
+    # Second read returns same cache object (no re-parse)
+    _ = p.trust_scores
+    assert p._parsed_cache is cache_after_first, (
+        "Cache must not re-parse on repeated read"
+    )
+
+    # add_signature bumps version, next read re-parses
+    jws2 = _make_jws(trust_score=80)
+    p.add_signature(jws2)
+    _ = p.trust_scores
+    assert p._parsed_cache is not cache_after_first, (
+        "Cache must re-parse after add_signature"
+    )
+
+
+def test_passport_accumulated_taints_returns_frozenset():
+    """A-03-II: accumulated_taints returns frozenset (immutable, O(1))."""
+    p = Passport()
+    p.add_signature(_make_jws(taints=["pii", "user_input"]))
+    result = p.accumulated_taints
+    assert isinstance(result, frozenset), (
+        f"accumulated_taints must return frozenset, got {type(result).__name__}"
+    )
+    assert result == {"pii", "user_input"}
+
+
+def test_passport_accumulated_taints_incremental():
+    """A-03-II: Incremental accumulation matches full recomputation."""
+    p = Passport()
+    p.add_signature(_make_jws(taints=["t1", "t2"]))
+    p.add_signature(_make_jws(taints=["t2", "t3"]))
+    p.add_signature(_make_jws(taints=["t4"]))
+    assert p.accumulated_taints == frozenset({"t1", "t2", "t3", "t4"})
+
+
+def test_passport_accumulated_taints_empty():
+    """A-03-II: Empty passport returns empty frozenset."""
+    p = Passport()
+    assert p.accumulated_taints == frozenset()
+    assert isinstance(p.accumulated_taints, frozenset)
+
+
+def test_passport_min_trust_score_property():
+    """A-03-II: min_trust_score returns the minimum across all entries."""
+    p = Passport()
+    p.add_signature(_make_jws(trust_score=90))
+    p.add_signature(_make_jws(trust_score=40))
+    p.add_signature(_make_jws(trust_score=70))
+    assert p.min_trust_score == 40
+
+
+def test_passport_min_trust_score_empty():
+    """A-03-II: Empty passport returns 100 (maximum trust)."""
+    p = Passport()
+    assert p.min_trust_score == 100
+
+
+def test_passport_slots_no_dict():
+    """A-03-III: Passport uses __slots__ — no __dict__ attribute."""
+    p = Passport()
+    assert not hasattr(p, "__dict__"), (
+        "Passport must use __slots__ (no __dict__ attribute)"
+    )
+
+
+def test_passport_deserialize_rebuilds_caches():
+    """Deserialize (via __post_init__) must rebuild incremental taint/trust caches."""
+    jws1 = _make_jws(trust_score=60, taints=["pii"])
+    jws2 = _make_jws(trust_score=80, taints=["external"])
+    original = Passport(entries=[jws1, jws2])
+    serialized = original.serialize()
+
+    restored = Passport.deserialize(serialized)
+    assert restored.accumulated_taints == frozenset({"pii", "external"})
+    assert restored.min_trust_score == 60
+
+
+def test_passport_merge_rebuilds_caches():
+    """Merge (via __post_init__) must rebuild incremental taint/trust caches."""
+    p1 = Passport(entries=[_make_jws(trust_score=50, taints=["t1"])])
+    p2 = Passport(entries=[_make_jws(trust_score=70, taints=["t2"])])
+    merged = Passport.merge(p1, p2)
+    assert merged.accumulated_taints == frozenset({"t1", "t2"})
+    assert merged.min_trust_score == 50
+
+
+# ===========================================================================
 # PassportVerifier (F-PA-04 – F-PA-07)
 # ===========================================================================
 

--- a/spec/learnings/v0.3.0/LEARNINGS.md
+++ b/spec/learnings/v0.3.0/LEARNINGS.md
@@ -253,58 +253,23 @@ This requires adding a `RustNativeIdentityProvider` pyclass that holds an `ed255
 
 ---
 
-### A-03: `Passport.accumulated_taints` and `trust_scores` Are Lazy-Cached Properties
+### A-03: `Passport.accumulated_taints` and `trust_scores` Are Lazy-Cached Properties — RESOLVED (2026-04-12)
 
 **File:** `models.py` — `Passport._get_parsed_entries()`  
 **Decision:** Parsing all JWS payloads in a passport on every `@kest_verified` call is O(n) in chain length. The parsed entries are cached in `_parsed_cache` and invalidated only when `entries` changes (via `add_signature()`).  
 **Why L1 Baggage is still a problem:** Even with caching, a 10-hop chain carries ~10 full JWS entries (~5KB raw, ~1.5KB compressed). Parsing is amortized, but the baggage size itself still triggers claim-check on very deep chains with incompressible (random-signed) data.
 
-**Weaknesses with the current approach:**
+**Resolved (2026-04-12, eterna2/kest#12):**
 
-1. **Snapshot comparison is O(n) on every property read.** `_get_parsed_entries()` compares `_entries_snapshot != self.entries` (a list equality check). For a 10-hop chain, this is a 10-element list comparison on every `trust_scores` or `accumulated_taints` read, even when nothing has changed. A version counter (`int`) would be O(1).
+> **A-03-I (RESOLVED):** Replaced list-snapshot comparison (`_entries_snapshot != self.entries`, O(n)) with integer version counter (`_cache_version != _version`, O(1)). The `_entries_snapshot` field was removed entirely.
 
-2. **`accumulated_taints` and `trust_scores` are recomputed from the full list on every property access.** After `_get_parsed_entries()` returns the cached list, `accumulated_taints` still iterates all entries to build the set union. A incrementally-maintained (`_taints_cache: frozenset`, `_min_trust: int`) would be O(1) per read after the first.
+> **A-03-II (RESOLVED):** `accumulated_taints` now returns `frozenset` in O(1) — maintained incrementally in `add_signature()`. New `min_trust_score` property returns `int` in O(1). `trust_scores` (per-entry list) still requires the parsed cache. The `frozenset` return type is an intentional minor API change — callers that need mutation must use `set(passport.accumulated_taints)`. The one internal caller in `decorators.py` was updated.
 
-3. **Dataclass `__eq__` is broken by the cache fields.** `_parsed_cache` is excluded via `compare=False`, but mutating it means two `Passport` instances with the same entries but different cache states are equal. This is correct but fragile if the pattern is extended.
+> **A-03-III (RESOLVED):** `@dataclass(slots=True)` added. No subclasses of `Passport` exist. Confirmed compatible with Python 3.11+ (pinned in `.prototools`).
 
-**Improvement Options:**
+**`__post_init__` note:** `Passport(entries=[...])` (used by `merge()`, `deserialize()`, and direct construction) triggers `__post_init__()` which rebuilds `_taints_cache`, `_min_trust_cache`, and `_version` from the initial entries. This ensures correct caches regardless of construction path.
 
-> **A-03-I (low effort, immediate):** Replace list-snapshot comparison with a version counter:
-
-```python
-@dataclass
-class Passport:
-    entries: List[str] = field(default_factory=list)
-    _version: int = field(default=0, repr=False, compare=False)
-    _parsed_cache: ... = field(default=None, repr=False, compare=False)
-
-    def _get_parsed_entries(self):
-        if self._parsed_cache is None or self._cache_version != self._version:
-            self._parsed_cache = [self._decode_payload(e) for e in self.entries]
-            self._cache_version = self._version
-        return self._parsed_cache
-
-    def add_signature(self, signature: str):
-        self.entries.append(signature)
-        self._version += 1  # O(1) invalidation
-```
-
-> **A-03-II (medium effort):** Maintain `accumulated_taints` and `min_trust_score` as incrementally-updated fields on `add_signature`:
-
-```python
-def add_signature(self, signature: str):
-    payload = self._decode_payload(signature)  # parse once
-    self.entries.append(signature)
-    self._taints |= set(payload.get("taints", []))  # O(1) incremental union
-    self._min_trust = min(self._min_trust, payload.get("trust_score", 100))
-    self._version += 1
-```
-
-This makes `accumulated_taints` and `min_trust` O(1) property reads and moves the O(1) parse work into `add_signature` — which is already O(n) string work anyway.
-
-> **A-03-III (medium effort):** Add `__slots__ = True` (Python 3.10+ dataclass option) to `Passport`. For a high-throughput service creating thousands of Passport objects per second, `__slots__` reduces per-instance memory by ~40–60 bytes and speeds up attribute access. This requires moving `_parsed_cache`, `_entries_snapshot`, and similar private fields to slotted fields. **Note:** `__slots__` and `dataclass(frozen=True)` are compatible; `__slots__` and mutable cache fields are also compatible (slots don’t imply immutability).
-
-> **A-03-IV (architectural, high effort):** The real long-term fix for L1 baggage explosion is not parsing optimization but **payload slimming** — the Passport wire format sends full JWS entries including headers and large policy context fields. A dedicated "summary" baggage key (`kest.summary`) could carry only `[entry_id, trust_score, taints[], chain_tip]` per hop, with full JWS available via claim-check lookup. This would reduce the per-hop baggage contribution from ~500 bytes to ~80 bytes, pushing the inline threshold from hop 8 to ~52 hops.
+**Test coverage (2026-04-12):** `models_test.py` — `test_passport_version_counter_invalidation`, `test_passport_accumulated_taints_returns_frozenset`, `test_passport_accumulated_taints_incremental`, `test_passport_accumulated_taints_empty`, `test_passport_min_trust_score_property`, `test_passport_min_trust_score_empty`, `test_passport_slots_no_dict`, `test_passport_deserialize_rebuilds_caches`, `test_passport_merge_rebuilds_caches`.
 
 **Tracking:** [eterna2/kest#12](https://github.com/eterna2/kest/issues/12)
 

--- a/website/content/reference/02_models.md
+++ b/website/content/reference/02_models.md
@@ -81,6 +81,7 @@ Standard trust scores for root nodes based on their origin. Scores are **integer
 |---|---|---|
 | `entries` | `List[str]` | Ordered list of JWS signatures (the Merkle chain) |
 | `trust_scores` | `List[int]` | Trust score of each entry (cached, O(1) after first read) |
-| `accumulated_taints` | `set` | Union of all taints across all entries (cached) |
+| `accumulated_taints` | `frozenset` | Union of all taints across all entries (O(1) after `add_signature`) |
+| `min_trust_score` | `int` | Minimum trust score across all entries (O(1) after `add_signature`) |
 
-> **Performance note:** `accumulated_taints` and `trust_scores` are read from a parsed-entries cache. The cache is invalidated on every `add_signature()` call. See [GitHub #12](https://github.com/eterna2/kest/issues/12) for planned O(1) incremental accumulation.
+> **Performance note:** `accumulated_taints` and `min_trust_score` are maintained incrementally in `add_signature()` and return in O(1). `trust_scores` uses a version-counted parsed-entries cache with O(1) invalidation check. The `Passport` class uses `__slots__` for reduced memory footprint. See [GitHub #12](https://github.com/eterna2/kest/issues/12).


### PR DESCRIPTION
## Summary

Resolves #12 — Three optimizations to the `Passport` class in `models.py`:

### A-03-I: O(1) Cache Invalidation (Version Counter)
- **Before:** `_get_parsed_entries()` compared `_entries_snapshot != self.entries` — an O(n) list equality check on every `trust_scores` or `accumulated_taints` read.
- **After:** Integer version counter (`_version` / `_cache_version`) — O(1) comparison. The `_entries_snapshot` field is removed entirely.

### A-03-II: O(1) Incremental Taint/Trust Aggregation
- `accumulated_taints` now returns `frozenset` in O(1) — maintained incrementally in `add_signature()`.
- New `min_trust_score` property returns `int` in O(1).
- `__post_init__()` rebuilds caches from initial entries for `merge()`, `deserialize()`, and direct construction paths.

### A-03-III: `__slots__` for Memory Efficiency
- `@dataclass(slots=True)` reduces per-instance memory by ~40–60 bytes and speeds up attribute access.
- No subclasses of `Passport` exist (verified).

## Breaking Changes
- `accumulated_taints` return type: `set` → `frozenset`
  - The one internal caller in `decorators.py` was updated (`set(passport.accumulated_taints)` for mutable copy).
  - `frozenset` supports `==` comparison with `set`, so existing assertion-style code is unaffected.

## Files Changed
| File | Change |
|---|---|
| `models.py` | Passport class: version counter, incremental aggregates, slots, `__post_init__` |
| `models_test.py` | 9 new tests covering all optimization aspects |
| `decorators.py` | Consumer fix for frozenset API |
| `02_models.md` | Updated property table and performance note |
| `LEARNINGS.md` | A-03-I/II/III marked as RESOLVED |

## Verification
- ✅ `moon run kest-core-python:format` — 2 files reformatted
- ✅ `moon run kest-core-python:lint` — all changed files pass (0 errors)
- ✅ `moon run kest-core-python:test` — **157/157 passed**
- ✅ `moon run kest-core-python:test-live` — **17/17 passed**