### PR TITLE
ci: fix pypa/gh-action-pypi-publish version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: wheels
           path: dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,6 @@ jobs:
           name: wheels
           path: dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v2.0.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist


### PR DESCRIPTION
Fixes the non-existent pypa/gh-action-pypi-publish action tag. The action version `v2.0.0` does not exist, so it was updated to the canonical `release/v1` tag as recommended by PyPA.