### PR TITLE
ci: specify PyPI environment for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: startsWith(github.ref, 'refs/tags/')
+    environment: pypi
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Fixes trusted publisher execution by adding the pypi environment mapping.