### PR TITLE
fix(core): add pyproject descriptions and bump to 0.3.0.post1

### DIFF
--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.1] - 2026-04-19
+## [0.3.0.post1] - 2026-04-19
 
 - **Fix**: Added explicit `description` and `readme` parameters to the core `pyproject.toml` to correctly render documentation metadata on PyPI.
 - **CI**: Hardened action triggers by specifying absolute SHAs and binding the proper `pypi` Trusted Publisher OIDC environment payload.

--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-04-19
+
+- **Fix**: Added explicit `description` and `readme` parameters to the core `pyproject.toml` to correctly render documentation metadata on PyPI.
+- **CI**: Hardened action triggers by specifying absolute SHAs and binding the proper `pypi` Trusted Publisher OIDC environment payload.
+
 ## [0.3.0] - 2026-04-18
 
 > **v0.3.0 is a complete architectural rewrite.** The package has eliminated the legacy Rust backend and is now rebuilt from the ground up as a pure Python namespace package. Applications upgrading from any pre-release versions must migrate to the new `kest.core` API.

--- a/libs/kest-core/python/pyproject.toml
+++ b/libs/kest-core/python/pyproject.toml
@@ -9,6 +9,21 @@ version = "0.3.1"
 description = "A Zero-Trust validation and telemetry toolkit for multi-agent workloads."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
+authors = [
+    { name = "eterna2", email = "eterna2@users.noreply.github.com" }
+]
+license = { text = "Apache-2.0" }
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
 dependencies = [
     "opentelemetry-api>=1.41.0",
     "opentelemetry-sdk>=1.41.0",
@@ -18,6 +33,11 @@ dependencies = [
     "rfc8785>=0.1.4",
     "cryptography>=46.0.7",
 ]
+
+[project.urls]
+Homepage = "https://github.com/eterna2/kest/"
+Documentation = "https://eterna2.github.io/kest/"
+Repository = "https://github.com/eterna2/kest/"
 
 [project.scripts]
 kest-viz = "kest.cli.viz:main"

--- a/libs/kest-core/python/pyproject.toml
+++ b/libs/kest-core/python/pyproject.toml
@@ -5,7 +5,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kest"
-version = "0.3.0"
+version = "0.3.1"
+description = "A Zero-Trust validation and telemetry toolkit for multi-agent workloads."
+readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "opentelemetry-api>=1.41.0",

--- a/libs/kest-core/python/pyproject.toml
+++ b/libs/kest-core/python/pyproject.toml
@@ -9,9 +9,7 @@ version = "0.3.1"
 description = "A Zero-Trust validation and telemetry toolkit for multi-agent workloads."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
-authors = [
-    { name = "eterna2", email = "eterna2@users.noreply.github.com" }
-]
+authors = [{ name = "eterna2", email = "ceilingcat@kest.sh" }]
 license = { text = "Apache-2.0" }
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -22,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Security",
-    "Topic :: Software Development :: Libraries :: Python Modules"
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
     "opentelemetry-api>=1.41.0",
@@ -36,29 +34,18 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/eterna2/kest/"
-Documentation = "https://eterna2.github.io/kest/"
+Documentation = "https://eterna2.github.io/kest/stable"
 Repository = "https://github.com/eterna2/kest/"
 
 [project.scripts]
 kest-viz = "kest.cli.viz:main"
 
 [project.optional-dependencies]
-spiffe = [
-    "spiffe>=0.2.6",
-]
-aws = [
-    "boto3>=1.28.0",
-    "aioboto3>=15.5.0",
-]
-opa = [
-    "opa-python-client>=2.0.4",
-]
-cedar = [
-    "cedarpy>=4.8.0",
-]
-rego = [
-    "regopy>=0.3.0",
-]
+spiffe = ["spiffe>=0.2.6"]
+aws = ["boto3>=1.28.0", "aioboto3>=15.5.0"]
+opa = ["opa-python-client>=2.0.4"]
+cedar = ["cedarpy>=4.8.0"]
+rego = ["regopy>=0.3.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/kest"]

--- a/libs/kest-core/python/pyproject.toml
+++ b/libs/kest-core/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kest"
-version = "0.3.1"
+version = "0.3.0.post1"
 description = "A Zero-Trust validation and telemetry toolkit for multi-agent workloads."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
Fixes missing PyPI metadata and bumps SemVer so the OIDC trusted publishing action can safely deploy.