### PR TITLE
feat(core): add context accessor functions

### DIFF
--- a/libs/kest-core/python/src/kest/core/__init__.py
+++ b/libs/kest-core/python/src/kest/core/__init__.py
@@ -12,6 +12,13 @@ from typing import Any
 
 from kest.core._core import KestEntry, sign_entry, version
 from kest.core.framework.cache import CacheProvider, SimpleCache  # noqa: E402
+from kest.core.framework.context import (  # noqa: E402
+    get_current_agent,
+    get_current_jwt,
+    get_current_passport,
+    get_current_task,
+    get_current_user,
+)
 from kest.core.framework.decorators import invalidate_policy_cache, kest_verified  # noqa: E402
 from kest.core.engines.engine import (  # noqa: E402
     AVPPolicyEngine,
@@ -146,4 +153,9 @@ __all__ = [
     # Operations
     "sign_entry",
     "invalidate_policy_cache",
+    "get_current_user",
+    "get_current_agent",
+    "get_current_task",
+    "get_current_jwt",
+    "get_current_passport",
 ]

--- a/libs/kest-core/python/src/kest/core/framework/context.py
+++ b/libs/kest-core/python/src/kest/core/framework/context.py
@@ -1,9 +1,26 @@
 from opentelemetry import baggage
 
 
+def get_current_user():
+    """Reads kest.user from OTel Baggage."""
+    return baggage.get_baggage("kest.user")
+
+
+def get_current_agent():
+    """Reads kest.agent from OTel Baggage."""
+    return baggage.get_baggage("kest.agent")
+
+
+def get_current_task():
+    """Reads kest.task from OTel Baggage."""
+    return baggage.get_baggage("kest.task")
+
+
 def get_current_passport():
+    """Reads kest.passport from OTel Baggage."""
     return baggage.get_baggage("kest.passport")
 
 
 def get_current_jwt():
+    """Reads kest.jwt from OTel Baggage."""
     return baggage.get_baggage("kest.jwt")

--- a/libs/kest-core/python/src/kest/core/framework/context_test.py
+++ b/libs/kest-core/python/src/kest/core/framework/context_test.py
@@ -1,19 +1,44 @@
+import opentelemetry.context as otel_context
 from opentelemetry import baggage
 
-from kest.core.framework.context import get_current_jwt, get_current_passport
+from kest.core.framework.context import (
+    get_current_agent,
+    get_current_jwt,
+    get_current_passport,
+    get_current_task,
+    get_current_user,
+)
+
+
+def test_get_current_user():
+    ctx = baggage.set_baggage("kest.user", "alice")
+    token = otel_context.attach(ctx)
+    try:
+        assert get_current_user() == "alice"
+    finally:
+        otel_context.detach(token)
+
+
+def test_get_current_agent():
+    ctx = baggage.set_baggage("kest.agent", "bot-123")
+    token = otel_context.attach(ctx)
+    try:
+        assert get_current_agent() == "bot-123"
+    finally:
+        otel_context.detach(token)
+
+
+def test_get_current_task():
+    ctx = baggage.set_baggage("kest.task", "process-data")
+    token = otel_context.attach(ctx)
+    try:
+        assert get_current_task() == "process-data"
+    finally:
+        otel_context.detach(token)
 
 
 def test_get_current_passport():
     ctx = baggage.set_baggage("kest.passport", "test-passport")
-    # Note: set_baggage returns a new context, but for testing if it's set in the active baggage
-    # we might need to attach it if we were using the full SDK, but here we just want to see
-    # if our functions call the right thing.
-
-    # In a real scenario, we'd use baggage.set_baggage and then ensure it's in the current context.
-    # However, baggage.get_baggage(key, context=None) uses the current context.
-
-    import opentelemetry.context as otel_context
-
     token = otel_context.attach(ctx)
     try:
         assert get_current_passport() == "test-passport"
@@ -23,10 +48,21 @@ def test_get_current_passport():
 
 def test_get_current_jwt():
     ctx = baggage.set_baggage("kest.jwt", "test-jwt")
-    import opentelemetry.context as otel_context
-
     token = otel_context.attach(ctx)
     try:
         assert get_current_jwt() == "test-jwt"
+    finally:
+        otel_context.detach(token)
+
+
+def test_accessors_return_none_when_missing():
+    # Ensure a clean context
+    token = otel_context.attach(otel_context.get_current())
+    try:
+        assert get_current_user() is None
+        assert get_current_agent() is None
+        assert get_current_task() is None
+        assert get_current_passport() is None
+        assert get_current_jwt() is None
     finally:
         otel_context.detach(token)


### PR DESCRIPTION
I have implemented the requested context accessor functions in `libs/kest-core/python/src/kest/core/framework/context.py`, exposed them in `libs/kest-core/python/src/kest/core/__init__.py`, and added comprehensive tests in `libs/kest-core/python/src/kest/core/framework/context_test.py`. These functions allow for retrieving `kest.user`, `kest.agent`, `kest.task`, `kest.jwt`, and `kest.passport` from OpenTelemetry Baggage.

Fixes #76

---
*PR created automatically by Jules for task [3255568647573502682](https://jules.google.com/task/3255568647573502682) started by @eterna2*