### PR TITLE
feat(core): wire resource_id and resource_attr into @kest_verified policy context

### DIFF
--- a/libs/kest-core/python/src/kest/core/framework/decorators.py
+++ b/libs/kest-core/python/src/kest/core/framework/decorators.py
@@ -7,7 +7,7 @@ import json
 import os
 import time
 from threading import Lock
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 import opentelemetry.context as otel_context
 import uuid_utils
@@ -278,16 +278,22 @@ def get_active_deviations() -> List[Any]:
     return getattr(kest.core, "_active_deviations", [])
 
 
-def _build_mapped_context(func, context_map, args, kwargs):
+def _build_mapped_context(
+    sig, context_map, resource_id, resource_attr, args, kwargs
+):
     mapped_context = {}
     mapped_labels = {}
+    resolved_resource_id = None
+    resolved_resource_attr = {}
+
+    bound_args = sig.bind(*args, **kwargs)
+    bound_args.apply_defaults()
+    call_args = bound_args.arguments
+
     if context_map:
-        sig = inspect.signature(func)
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
         for arg_name, config in context_map.items():
-            if arg_name in bound_args.arguments:
-                val = bound_args.arguments[arg_name]
+            if arg_name in call_args:
+                val = call_args[arg_name]
                 if isinstance(config, dict):
                     ctx_key = config.get("key", arg_name)
                     persist = config.get("persist", False)
@@ -301,7 +307,25 @@ def _build_mapped_context(func, context_map, args, kwargs):
                         if not isinstance(val, (int, float, bool, str))
                         else val
                     )
-    return mapped_context, mapped_labels
+
+    if resource_id:
+        if callable(resource_id):
+            resolved_resource_id = resource_id(call_args)
+        else:
+            resolved_resource_id = resource_id
+
+    if resource_attr:
+        if callable(resource_attr):
+            resolved_resource_attr = resource_attr(call_args)
+        else:
+            resolved_resource_attr = resource_attr
+
+    return (
+        mapped_context,
+        mapped_labels,
+        resolved_resource_id,
+        resolved_resource_attr,
+    )
 
 
 def _execute_core_logic(
@@ -313,6 +337,8 @@ def _execute_core_logic(
     added_taints: Optional[List[str]],
     removed_taints: Optional[List[str]],
     context_map: Optional[dict],
+    resource_id: Optional[str],
+    resource_attr: Optional[dict],
     args: tuple,
     kwargs: dict,
     engine: Optional[PolicyEngine],
@@ -395,6 +421,10 @@ def _execute_core_logic(
         "task": _get_baggage("kest.task") or "",
         # Implementation extension: raw OAuth scope for Cedar ABAC checks
         "scope": _get_baggage("kest.scope") or "",
+        "object": {
+            "id": resource_id or "",
+            "attributes": resource_attr or {},
+        },
     }
 
     # Needs to be provided by caller logic:
@@ -422,6 +452,8 @@ def _execute_core_post_auth(
     added_taints,
     removed_taints,
     mapped_labels,
+    resource_id=None,
+    resource_attr=None,
 ):
     span = state["span"]
     labels = {"principal": state["principal"]}
@@ -434,6 +466,11 @@ def _execute_core_post_auth(
         labels["kest.trace_id"] = tracking_id
     if mapped_labels:
         labels.update(mapped_labels)
+
+    if resource_id:
+        labels["kest.resource_id"] = resource_id
+    if resource_attr:
+        labels["kest.resource_attr"] = json.dumps(resource_attr)
 
     # Spec §2.7 F-IC-04: embed user/agent in labels as kest.identity JSON string
     principal_user = _get_baggage("kest.user")
@@ -496,17 +533,25 @@ def kest_verified(
     removed_taints: Optional[List[str]] = None,
     trust_override: Optional[int] = None,
     context_map: Optional[dict] = None,
+    resource_id: Union[str, Callable, None] = None,
+    resource_attr: Union[dict, Callable, None] = None,
 ):
     _raw_policies = [policy] if isinstance(policy, str) else policy
     policies = list(dict.fromkeys(_raw_policies))
 
     def decorator(func):
         is_coroutine = inspect.iscoroutinefunction(func)
+        sig = inspect.signature(func)
 
         @functools.wraps(func)
         async def async_wrapper(*args, **kwargs):
-            mapped_context, mapped_labels = _build_mapped_context(
-                func, context_map, args, kwargs
+            (
+                mapped_context,
+                mapped_labels,
+                resolved_res_id,
+                resolved_res_attr,
+            ) = _build_mapped_context(
+                sig, context_map, resource_id, resource_attr, args, kwargs
             )
             state = _execute_core_logic(
                 func.__name__,
@@ -517,6 +562,8 @@ def kest_verified(
                 added_taints,
                 removed_taints,
                 context_map,
+                resolved_res_id,
+                resolved_res_attr,
                 args,
                 kwargs,
                 engine,
@@ -559,6 +606,8 @@ def kest_verified(
                     added_taints,
                     removed_taints,
                     mapped_labels,
+                    resolved_res_id,
+                    resolved_res_attr,
                 )
                 token = otel_context.attach(new_ctx)
                 try:
@@ -568,8 +617,13 @@ def kest_verified(
 
         @functools.wraps(func)
         def sync_wrapper(*args, **kwargs):
-            mapped_context, mapped_labels = _build_mapped_context(
-                func, context_map, args, kwargs
+            (
+                mapped_context,
+                mapped_labels,
+                resolved_res_id,
+                resolved_res_attr,
+            ) = _build_mapped_context(
+                sig, context_map, resource_id, resource_attr, args, kwargs
             )
             state = _execute_core_logic(
                 func.__name__,
@@ -580,6 +634,8 @@ def kest_verified(
                 added_taints,
                 removed_taints,
                 context_map,
+                resolved_res_id,
+                resolved_res_attr,
                 args,
                 kwargs,
                 engine,
@@ -608,7 +664,13 @@ def kest_verified(
                     raise PermissionError(f"Kest policies {policies} denied execution")
 
                 new_ctx = _execute_core_post_auth(
-                    state, func.__name__, added_taints, removed_taints, mapped_labels
+                    state,
+                    func.__name__,
+                    added_taints,
+                    removed_taints,
+                    mapped_labels,
+                    resolved_res_id,
+                    resolved_res_attr,
                 )
                 token = otel_context.attach(new_ctx)
                 try:

--- a/libs/kest-core/python/src/kest/core/framework/resource_test.py
+++ b/libs/kest-core/python/src/kest/core/framework/resource_test.py
@@ -1,0 +1,134 @@
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry import trace
+
+import kest.core
+from kest.core.engines.engine import PolicyEngine
+from kest.core.framework.decorators import kest_verified
+from kest.core.identity import IdentityProvider
+
+# Mock Tracer to avoid OTel overhead in tests
+tracer = trace.get_tracer(__name__)
+
+class MockEngine(PolicyEngine):
+    def __init__(self):
+        self.last_context = None
+        self.evaluate_result = True
+
+    def evaluate(self, entry_id, policy_names, context):
+        self.last_context = context
+        return self.evaluate_result
+
+class MockIdentity(IdentityProvider):
+    def get_identity(self):
+        return "test-principal"
+    def sign(self, payload):
+        return "header.payload.signature"
+
+@pytest.fixture(autouse=True)
+def mock_kest_globals():
+    engine = MockEngine()
+    identity = MockIdentity()
+    kest.core.configure(engine=engine, identity=identity)
+    kest.core.invalidate_policy_cache()
+    yield engine, identity
+    kest.core.configure(clear=True)
+    kest.core.invalidate_policy_cache()
+
+def test_static_resource_id_and_attr(mock_kest_globals):
+    engine, identity = mock_kest_globals
+
+    @kest_verified(
+        policy="test-policy",
+        resource_id="static-res-1",
+        resource_attr={"type": "document", "owner": "alice"}
+    )
+    def my_function():
+        return "ok"
+
+    with patch("kest.core.framework.decorators.sign_entry", wraps=kest.core.sign_entry) as mock_sign:
+        my_function()
+
+        # Verify context passed to engine
+        assert engine.last_context["object"]["id"] == "static-res-1"
+        assert engine.last_context["object"]["attributes"] == {"type": "document", "owner": "alice"}
+
+        # Verify labels in signed entry
+        assert mock_sign.called
+        args, _ = mock_sign.call_args
+        entry = args[0]
+        assert entry.labels["kest.resource_id"] == "static-res-1"
+        assert entry.labels["kest.resource_attr"] == json.dumps({"type": "document", "owner": "alice"})
+
+def test_resolver_resource_id_and_attr(mock_kest_globals):
+    engine, identity = mock_kest_globals
+
+    def res_id_resolver(args):
+        return f"res-{args['doc_id']}"
+
+    def res_attr_resolver(args):
+        return {"category": args["cat"], "priority": args["pri"]}
+
+    @kest_verified(
+        policy="test-policy",
+        resource_id=res_id_resolver,
+        resource_attr=res_attr_resolver
+    )
+    def my_function(doc_id, cat, pri=1):
+        return "ok"
+
+    with patch("kest.core.framework.decorators.sign_entry", wraps=kest.core.sign_entry) as mock_sign:
+        my_function("123", "legal", pri=5)
+
+        assert engine.last_context["object"]["id"] == "res-123"
+        assert engine.last_context["object"]["attributes"] == {"category": "legal", "priority": 5}
+
+        args, _ = mock_sign.call_args
+        entry = args[0]
+        assert entry.labels["kest.resource_id"] == "res-123"
+        assert entry.labels["kest.resource_attr"] == json.dumps({"category": "legal", "priority": 5})
+
+@pytest.mark.asyncio
+async def test_async_resource_id_and_attr(mock_kest_globals):
+    engine, identity = mock_kest_globals
+
+    @kest_verified(
+        policy="test-policy",
+        resource_id=lambda args: f"async-{args['id']}",
+        resource_attr={"mode": "async"}
+    )
+    async def my_async_function(id):
+        await asyncio.sleep(0)
+        return "async-ok"
+
+    with patch("kest.core.framework.decorators.sign_entry", wraps=kest.core.sign_entry) as mock_sign:
+        result = await my_async_function("999")
+        assert result == "async-ok"
+
+        assert engine.last_context["object"]["id"] == "async-999"
+        assert engine.last_context["object"]["attributes"] == {"mode": "async"}
+
+        args, _ = mock_sign.call_args
+        entry = args[0]
+        assert entry.labels["kest.resource_id"] == "async-999"
+        assert entry.labels["kest.resource_attr"] == json.dumps({"mode": "async"})
+
+def test_no_resource_provided(mock_kest_globals):
+    engine, identity = mock_kest_globals
+
+    @kest_verified(policy="test-policy")
+    def my_function():
+        return "ok"
+
+    with patch("kest.core.framework.decorators.sign_entry", wraps=kest.core.sign_entry) as mock_sign:
+        my_function()
+
+        assert engine.last_context["object"]["id"] == ""
+        assert engine.last_context["object"]["attributes"] == {}
+
+        args, _ = mock_sign.call_args
+        entry = args[0]
+        assert "kest.resource_attr" not in entry.labels

--- a/libs/kest-core/python/uv.lock
+++ b/libs/kest-core/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -856,7 +856,7 @@ wheels = [
 
 [[package]]
 name = "kest"
-version = "0.3.0"
+version = "0.3.0.post1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR implements support for resource identifiers and attributes in the `@kest_verified` decorator, enabling Attribute-Based Access Control (ABAC) in security policies.

Key changes:
1.  **Decorator Update**: `@kest_verified` now accepts optional `resource_id` and `resource_attr` parameters. These can be static values or callables that resolve data from the function's arguments.
2.  **Policy Context**: Resolved resource data is passed to the policy engine in the `object` block (e.g., `input.object.id` and `input.object.attributes` in Rego/Cedar).
3.  **Signed Audit Labels**: The `resource_id` and `resource_attr` (as JSON) are embedded into the `KestEntry` labels (`kest.resource_id` and `kest.resource_attr`), ensuring they are part of the cryptographically signed audit trail.
4.  **Performance Optimization**: To minimize runtime overhead, function signatures are pre-calculated using `inspect.signature` once at decoration time rather than on every invocation.
5.  **Testing**: Added `libs/kest-core/python/src/kest/core/framework/resource_test.py` covering various use cases including static values, resolvers, and both sync and async decorated functions.

This satisfies the requirements specified in Kest SPEC-v0.3.0.

Fixes #77

---
*PR created automatically by Jules for task [13423310116414574317](https://jules.google.com/task/13423310116414574317) started by @eterna2*