### PR TITLE
feat(core): wire resource_id and resource_attr into @kest_verified (F-IC-01, F-IC-02, F-IC-04) (#77)

### DIFF
--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Resource Context** (F-IC-01, F-IC-02, F-IC-04): Added `resource_id` (str | Callable) and
+  `resource_attr` (dict | Callable) parameters to `@kest_verified`. Both accept static values
+  or resolver callables that are invoked with the decorated function's arguments at call time.
+  Resolved values are forwarded to the policy engine as `object.id` / `object.attributes` per
+  SPEC-v0.3.0 §9.2 (F-IC-01, F-IC-02) and serialized into `KestEntry.labels["kest.resource_attr"]`
+  for tamper-evident audit (F-IC-04). The policy decision cache key now includes `resource_id` to
+  prevent cross-resource ABAC cache collisions.
 - **Context Accessor Functions** (F-CP-06): Implemented the five public context accessor functions required by SPEC-v0.3.0 §2.8:
   - `get_current_user()` — reads `kest.user` from OTel Baggage
   - `get_current_agent()` — reads `kest.agent` from OTel Baggage

--- a/libs/kest-core/python/README.md
+++ b/libs/kest-core/python/README.md
@@ -99,6 +99,10 @@ Engines like Rego or Cedar evaluate the context state precisely. Kest maps its e
     "trust_score": 80,                   // Cumulative CARTA integer (0-100)
     "taints": ["contains_phi"]           // Active cumulated risk profiles
   },
+  "object": {
+    "id": "document:42",                 // Resource identifier (resource_id param)
+    "attributes": { "dept": "finance" }  // Resource attributes (resource_attr param)
+  },
   "environment": {
     "parent_hash": "e3b0c442...",        // Deterministic previous-hop JWS signature
     "policy_names": ["financial_access"] // Active policies triggered for current execution
@@ -137,7 +141,35 @@ has_taint(t) {
 }
 ```
 
-### 3. Policy Validation
+### 3. Resource Context (ABAC)
+
+For Attribute-Based Access Control, pass `resource_id` and `resource_attr` to `@kest_verified`. Both accept a static value or a **resolver** — a callable that receives the decorated function's arguments at call time.
+
+```python
+from kest.core import kest_verified
+
+# Static resource identity
+@kest_verified(
+    policy="document_read",
+    resource_id="documents:42",
+    resource_attr={"dept": "finance", "classification": "confidential"},
+)
+def read_document(doc_id: str) -> dict:
+    ...
+
+# Resolver: derive resource context dynamically from function arguments
+@kest_verified(
+    policy="document_read",
+    resource_id=lambda doc_id, **kw: f"documents:{doc_id}",
+    resource_attr=lambda doc_id, **kw: {"dept": "finance"},
+)
+def read_document_dynamic(doc_id: str) -> dict:
+    ...
+```
+
+Resolved values are forwarded to the policy engine as `object.id` / `object.attributes` per SPEC §9.2 and serialized into `KestEntry.labels["kest.resource_attr"]` for tamper-evident audit.
+
+### 4. Policy Validation
 To prevent faulty configurations, Kest provides static AST syntax validations that can proactively check LLM-generated or static policies before deploying them:
 
 ```python

--- a/libs/kest-core/python/src/kest/core/framework/decorators.py
+++ b/libs/kest-core/python/src/kest/core/framework/decorators.py
@@ -7,7 +7,7 @@ import json
 import os
 import time
 from threading import Lock
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 import opentelemetry.context as otel_context
 import uuid_utils
@@ -67,6 +67,9 @@ class _PolicyDecisionCache:
             context.get("user", ""),
             context.get("agent", ""),
             context.get("task", ""),
+            # ABAC resource axis — MUST be in cache key to prevent cross-resource
+            # collisions where different resource IDs share a cached allow decision.
+            context.get("object", {}).get("id", "") or "",
         )
 
     def get_or_evaluate(
@@ -278,6 +281,32 @@ def get_active_deviations() -> List[Any]:
     return getattr(kest.core, "_active_deviations", [])
 
 
+def _build_resource_context(
+    resource_id: Optional[Union[str, Callable]],
+    resource_attr: Optional[Union[dict, Callable]],
+    args: tuple,
+    kwargs: dict,
+) -> tuple:
+    """
+    Resolve resource_id and resource_attr at call time.
+
+    If the value is callable, it is invoked with (*args, **kwargs) of the
+    decorated function and must return the resolved value.  Static values
+    are returned as-is.  None → None.
+
+    Returns:
+        (resolved_id, resolved_attr) where resolved_id is str|None and
+        resolved_attr is dict|None.
+    """
+    resolved_id: Optional[str] = (
+        resource_id(*args, **kwargs) if callable(resource_id) else resource_id
+    )
+    resolved_attr: Optional[dict] = (
+        resource_attr(*args, **kwargs) if callable(resource_attr) else resource_attr
+    )
+    return resolved_id, resolved_attr
+
+
 def _build_mapped_context(func, context_map, args, kwargs):
     mapped_context = {}
     mapped_labels = {}
@@ -317,6 +346,8 @@ def _execute_core_logic(
     kwargs: dict,
     engine: Optional[PolicyEngine],
     identity: Optional[IdentityProvider],
+    resolved_resource_id: Optional[str] = None,
+    resolved_resource_attr: Optional[dict] = None,
 ):
     """Shared core logic extracted to prevent duplication between sync and async execution paths."""
     active_id = identity or get_active_identity()
@@ -395,6 +426,11 @@ def _execute_core_logic(
         "task": _get_baggage("kest.task") or "",
         # Implementation extension: raw OAuth scope for Cedar ABAC checks
         "scope": _get_baggage("kest.scope") or "",
+        # SPEC-v0.3.0 §9.2 — resource context for ABAC (F-IC-01, F-IC-02)
+        "object": {
+            "id": resolved_resource_id,
+            "attributes": resolved_resource_attr or {},
+        },
     }
 
     # Needs to be provided by caller logic:
@@ -422,6 +458,7 @@ def _execute_core_post_auth(
     added_taints,
     removed_taints,
     mapped_labels,
+    resource_attr: Optional[dict] = None,
 ):
     span = state["span"]
     labels = {"principal": state["principal"]}
@@ -442,6 +479,10 @@ def _execute_core_post_auth(
         labels["kest.identity"] = json.dumps(
             {"user": principal_user or "", "agent": principal_agent or ""}
         )
+
+    # Spec §2.7 F-IC-04: embed resource_attr in labels as kest.resource_attr JSON string
+    if resource_attr:
+        labels["kest.resource_attr"] = json.dumps(resource_attr)
 
     entry = KestEntry(
         entry_id=state["entry_id"],
@@ -496,7 +537,31 @@ def kest_verified(
     removed_taints: Optional[List[str]] = None,
     trust_override: Optional[int] = None,
     context_map: Optional[dict] = None,
+    resource_id: Optional[Union[str, Callable]] = None,
+    resource_attr: Optional[Union[dict, Callable]] = None,
 ):
+    """
+    Decorator that wraps a function with Kest zero-trust policy enforcement.
+
+    Args:
+        policy: Policy name(s) to evaluate (logical AND).
+        engine: Per-invocation PolicyEngine override.
+        identity: Per-invocation IdentityProvider override.
+        trust_evaluator: Per-invocation TrustEvaluator override.
+        origin: Source type for root-node trust bootstrapping.
+        added_taints: Taint labels to introduce at this node.
+        removed_taints: Taint labels to clear at this node.
+        trust_override: Hard-set trust_score bypassing the evaluator (sanitizer).
+        context_map: Map of function argument names to policy context keys.
+        resource_id: Resource identifier for ABAC.  Accepts a static string or a
+            callable (resolver) that receives the function's (*args, **kwargs) and
+            returns a string.  Forwarded as ``object.id`` in the policy context
+            (SPEC-v0.3.0 §9.2, F-IC-01).
+        resource_attr: Resource attributes for ABAC.  Accepts a static dict or a
+            callable (resolver) that receives (*args, **kwargs) and returns a dict.
+            Forwarded as ``object.attributes`` in the policy context and serialized
+            into ``KestEntry.labels["kest.resource_attr"]`` (F-IC-01, F-IC-04).
+    """
     _raw_policies = [policy] if isinstance(policy, str) else policy
     policies = list(dict.fromkeys(_raw_policies))
 
@@ -507,6 +572,9 @@ def kest_verified(
         async def async_wrapper(*args, **kwargs):
             mapped_context, mapped_labels = _build_mapped_context(
                 func, context_map, args, kwargs
+            )
+            resolved_rid, resolved_rattr = _build_resource_context(
+                resource_id, resource_attr, args, kwargs
             )
             state = _execute_core_logic(
                 func.__name__,
@@ -521,6 +589,8 @@ def kest_verified(
                 kwargs,
                 engine,
                 identity,
+                resolved_resource_id=resolved_rid,
+                resolved_resource_attr=resolved_rattr,
             )
 
             span = state["span"]
@@ -559,6 +629,7 @@ def kest_verified(
                     added_taints,
                     removed_taints,
                     mapped_labels,
+                    resolved_rattr,
                 )
                 token = otel_context.attach(new_ctx)
                 try:
@@ -570,6 +641,9 @@ def kest_verified(
         def sync_wrapper(*args, **kwargs):
             mapped_context, mapped_labels = _build_mapped_context(
                 func, context_map, args, kwargs
+            )
+            resolved_rid, resolved_rattr = _build_resource_context(
+                resource_id, resource_attr, args, kwargs
             )
             state = _execute_core_logic(
                 func.__name__,
@@ -584,6 +658,8 @@ def kest_verified(
                 kwargs,
                 engine,
                 identity,
+                resolved_resource_id=resolved_rid,
+                resolved_resource_attr=resolved_rattr,
             )
 
             span = state["span"]
@@ -608,7 +684,12 @@ def kest_verified(
                     raise PermissionError(f"Kest policies {policies} denied execution")
 
                 new_ctx = _execute_core_post_auth(
-                    state, func.__name__, added_taints, removed_taints, mapped_labels
+                    state,
+                    func.__name__,
+                    added_taints,
+                    removed_taints,
+                    mapped_labels,
+                    resolved_rattr,
                 )
                 token = otel_context.attach(new_ctx)
                 try:

--- a/libs/kest-core/python/src/kest/core/resource_context_test.py
+++ b/libs/kest-core/python/src/kest/core/resource_context_test.py
@@ -1,0 +1,297 @@
+"""
+TDD tests for resource_id and resource_attr parameters on @kest_verified.
+
+Spec reference: SPEC-v0.3.0 §2.7 F-IC-01, F-IC-02, F-IC-04 and §9.2.
+
+These tests MUST BE WRITTEN BEFORE the implementation and must initially fail (RED).
+
+All tests use MockPolicyEngine with an evaluate() override that captures the
+context dict passed during policy evaluation, allowing assertions on the
+structure of ctx_to_eval["object"] without requiring a live policy sidecar.
+"""
+
+import asyncio
+
+from kest.core import (
+    MockIdentityProvider,
+    MockPolicyEngine,
+    configure,
+    kest_verified,
+)
+from kest.core.framework.decorators import invalidate_policy_cache
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _CapturingEngine(MockPolicyEngine):
+    """MockPolicyEngine that records every context dict passed to evaluate()."""
+
+    def __init__(self, allow_all: bool = True):
+        super().__init__(allow_all=allow_all)
+        self.captured_contexts: list[dict] = []
+
+    def evaluate(self, entry_id, policy_names, context):
+        self.captured_contexts.append(context)
+        return self.allow_all  # type: ignore[attr-defined]
+
+
+def _fresh_engine() -> _CapturingEngine:
+    engine = _CapturingEngine(allow_all=True)
+    configure(engine=engine, identity=MockIdentityProvider(), clear=True)
+    invalidate_policy_cache()
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Static resource_id tests
+# ---------------------------------------------------------------------------
+
+
+def test_resource_id_static_forwarded_to_policy_context():
+    """resource_id='res-1' must appear as context['object']['id'] == 'res-1'."""
+    engine = _fresh_engine()
+
+    @kest_verified(policy="test", resource_id="res-1")
+    def op():
+        return "ok"
+
+    result = op()
+    assert result == "ok"
+    assert len(engine.captured_contexts) == 1
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["id"] == "res-1"
+
+
+def test_resource_id_none_sets_null_in_object_id():
+    """When resource_id=None, context['object']['id'] must be None."""
+    engine = _fresh_engine()
+
+    @kest_verified(policy="test", resource_id=None)
+    def op():
+        return "ok"
+
+    op()
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["id"] is None
+
+
+# ---------------------------------------------------------------------------
+# resource_id resolver tests
+# ---------------------------------------------------------------------------
+
+
+def test_resource_id_resolver_called_with_invocation_args():
+    """A callable resource_id receives the decorated function's arguments."""
+    engine = _fresh_engine()
+
+    @kest_verified(policy="test", resource_id=lambda doc_id, **kw: doc_id)
+    def op(doc_id: str):
+        return doc_id
+
+    op("doc-42")
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["id"] == "doc-42"
+
+
+def test_resource_id_resolver_with_kwargs():
+    """A callable resource_id can extract values from keyword arguments."""
+    engine = _fresh_engine()
+
+    @kest_verified(
+        policy="test", resource_id=lambda *args, **kwargs: kwargs.get("resource")
+    )
+    def op(resource: str = ""):
+        return resource
+
+    op(resource="kw-res")
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["id"] == "kw-res"
+
+
+# ---------------------------------------------------------------------------
+# Static resource_attr tests
+# ---------------------------------------------------------------------------
+
+
+def test_resource_attr_static_forwarded_to_policy_context():
+    """Static resource_attr dict must appear as context['object']['attributes']."""
+    engine = _fresh_engine()
+    attrs = {"dept": "engineering", "classification": "internal"}
+
+    @kest_verified(policy="test", resource_attr=attrs)
+    def op():
+        return "ok"
+
+    op()
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["attributes"] == attrs
+
+
+def test_resource_attr_none_sets_empty_dict_in_object_attributes():
+    """When resource_attr=None, context['object']['attributes'] must be {}."""
+    engine = _fresh_engine()
+
+    @kest_verified(policy="test", resource_attr=None)
+    def op():
+        return "ok"
+
+    op()
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["attributes"] == {}
+
+
+# ---------------------------------------------------------------------------
+# resource_attr resolver tests
+# ---------------------------------------------------------------------------
+
+
+def test_resource_attr_resolver_called_with_invocation_args():
+    """A callable resource_attr receives the decorated function's arguments."""
+    engine = _fresh_engine()
+
+    def resolve_attrs(category: str, **kw):
+        return {"category": category, "sensitive": False}
+
+    @kest_verified(policy="test", resource_attr=resolve_attrs)
+    def op(category: str):
+        return category
+
+    op("legal")
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["attributes"] == {"category": "legal", "sensitive": False}
+
+
+# ---------------------------------------------------------------------------
+# KestEntry label embedding (F-IC-04)
+# ---------------------------------------------------------------------------
+
+
+def test_resource_attr_embedded_in_kest_entry_labels():
+    """Resolved resource_attr must be serialized into labels['kest.resource_attr']."""
+    import json as _json
+
+    _fresh_engine()
+    captured_entries: list = []
+
+    # Patch sign_entry to capture the KestEntry before signing
+    import kest.core._core as _core_mod
+
+    original_sign = _core_mod.sign_entry
+
+    def capturing_sign(entry, identity):
+        captured_entries.append(entry)
+        return original_sign(entry, identity)
+
+    _core_mod.sign_entry = capturing_sign
+
+    import kest.core as kest_core_mod
+
+    kest_core_mod.sign_entry = capturing_sign
+
+    import kest.core.framework.decorators as dec_mod
+
+    dec_mod.sign_entry = capturing_sign
+
+    try:
+        attrs = {"dept": "finance"}
+
+        @kest_verified(policy="test", resource_attr=attrs)
+        def op():
+            return "ok"
+
+        op()
+    finally:
+        _core_mod.sign_entry = original_sign
+        kest_core_mod.sign_entry = original_sign
+        dec_mod.sign_entry = original_sign
+
+    assert len(captured_entries) >= 1
+    entry = captured_entries[0]
+    assert "kest.resource_attr" in entry.labels
+    assert _json.loads(entry.labels["kest.resource_attr"]) == attrs
+
+
+def test_resource_attr_not_in_labels_when_none():
+    """When resource_attr=None, labels must NOT contain 'kest.resource_attr'."""
+    import kest.core._core as _core_mod
+
+    _fresh_engine()
+    captured_entries: list = []
+    original_sign = _core_mod.sign_entry
+
+    def capturing_sign(entry, identity):
+        captured_entries.append(entry)
+        return original_sign(entry, identity)
+
+    _core_mod.sign_entry = capturing_sign
+
+    import kest.core as kest_core_mod
+
+    kest_core_mod.sign_entry = capturing_sign
+
+    import kest.core.framework.decorators as dec_mod
+
+    dec_mod.sign_entry = capturing_sign
+
+    try:
+
+        @kest_verified(policy="test", resource_attr=None)
+        def op():
+            return "ok"
+
+        op()
+    finally:
+        _core_mod.sign_entry = original_sign
+        kest_core_mod.sign_entry = original_sign
+        dec_mod.sign_entry = original_sign
+
+    assert len(captured_entries) >= 1
+    entry = captured_entries[0]
+    assert "kest.resource_attr" not in entry.labels
+
+
+# ---------------------------------------------------------------------------
+# Cache isolation tests (security-critical)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_miss_on_different_resource_ids():
+    """Calls with different resource_id values must each trigger engine.evaluate()."""
+    engine = _CapturingEngine(allow_all=True)
+    configure(engine=engine, identity=MockIdentityProvider(), clear=True)
+    invalidate_policy_cache()
+
+    @kest_verified(policy="test", resource_id=lambda doc_id, **kw: doc_id)
+    def op(doc_id: str):
+        return doc_id
+
+    op("res-A")
+    op("res-B")
+
+    # Must have triggered evaluate() twice — one per resource
+    assert len(engine.captured_contexts) == 2
+    resource_ids = [c["object"]["id"] for c in engine.captured_contexts]
+    assert "res-A" in resource_ids
+    assert "res-B" in resource_ids
+
+
+# ---------------------------------------------------------------------------
+# Async path
+# ---------------------------------------------------------------------------
+
+
+def test_async_resource_id_forwarded():
+    """Async decorated function with resource_id must resolve and forward correctly."""
+    engine = _fresh_engine()
+
+    @kest_verified(policy="test", resource_id="async-res-99")
+    async def async_op():
+        return "ok"
+
+    result = asyncio.run(async_op())
+    assert result == "ok"
+    assert len(engine.captured_contexts) >= 1
+    ctx = engine.captured_contexts[0]
+    assert ctx["object"]["id"] == "async-res-99"

--- a/spec/learnings/v0.3.0/LEARNINGS.md
+++ b/spec/learnings/v0.3.0/LEARNINGS.md
@@ -39,7 +39,7 @@
 | Verification Hook lifecycle | F-PE-01 → F-PE-13 | ✅ Implemented | Steps 8→9→10→11 match spec exactly |
 | Trust score | F-TS-01 → F-TS-06 | ✅ Implemented | All default origin scores correct |
 | Taint tracking | F-TT-01 → F-TT-06 | ✅ Implemented | |
-| Identity context (user/agent/task) | F-IC-01 → F-IC-05 | ✅ Implemented | Baggage keys: `kest.user`, `kest.agent`, `kest.task` |
+| Identity context (user/agent/task/resource) | F-IC-01 → F-IC-05 | ✅ Implemented | `user`, `agent`, `task` via Baggage; `resource_id`/`resource_attr` via decorator params (Issue #77) |
 | Context propagation | F-CP-01 → F-CP-08 | ✅ Implemented | `kest.passport_z` (compressed) is now normative |
 | Telemetry | F-TE-01 → F-TE-04 | ✅ Implemented | |
 | Global configuration | F-GC-01 → F-GC-04 | ✅ Implemented | |
@@ -182,3 +182,21 @@ When subclassing a PyO3 class (e.g., `RustNativeIdentityProvider`), override `__
 
 ### A-06: V2 Context Normalization Resolution
 **Resolution**: While the `rust-v2` backend generically stores tracking context as strings for OTel payload validation (`BTreeMap<String, String>`), Kest explicitly implements Spec-Aware Type Coercion directly inside the Engine Adapters (Cedar, OPA, and Foreign FFI engines). This specifically parses and intercepts standard specification integer fields like `trust_score` before policy evaluation, ensuring strict type compliance across language boundaries.
+### T-07: Assert `context["object"]` Shape in Engine Override
+
+When testing `resource_id` / `resource_attr` forwarding, override `evaluate()` in a `MockPolicyEngine` subclass to capture the `context` dict:
+
+```python
+class _CapturingEngine(MockPolicyEngine):
+    def __init__(self): super().__init__(allow_all=True); self.contexts = []
+    def evaluate(self, entry_id, policy_names, context):
+        self.contexts.append(context); return True
+```
+
+Then assert:
+```python
+assert engine.contexts[0]["object"]["id"] == "expected-id"
+assert engine.contexts[0]["object"]["attributes"] == {"dept": "eng"}
+```
+
+This avoids patching internals and tests the full end-to-end resolver path.


### PR DESCRIPTION
## Summary

Implements [Issue #77](https://github.com/eterna2/kest/issues/77) — wires `resource_id` and `resource_attr` into the `@kest_verified` decorator to enable ABAC policies that make decisions based on the accessed resource.

## Changes

### `decorators.py`
- Add `resource_id` (`str | Callable`) and `resource_attr` (`dict | Callable`) parameters to `kest_verified()`
- Add `_build_resource_context()` helper — resolves static or callable values at call time using the decorated function's `(*args, **kwargs)`
- Extend `ctx_to_eval` with `object.id` / `object.attributes` per **SPEC-v0.3.0 §9.2** (F-IC-01, F-IC-02)
- Serialize resolved `resource_attr` into `KestEntry.labels["kest.resource_attr"]` (F-IC-04)
- Add `resource_id` to `_PolicyDecisionCache._make_key()` — **security-critical**: prevents ABAC cross-resource cache collisions
- Propagate resolved values through both `async_wrapper` and `sync_wrapper`

### Tests (`resource_context_test.py`) — TDD
11 new unit tests written **before** implementation (confirmed RED → GREEN):
- Static `resource_id` / `resource_attr` forwarded to policy context
- Callable resolvers invoked with function `args`/`kwargs`
- `KestEntry.labels["kest.resource_attr"]` embedding (F-IC-04)
- `None` defaults: `object.id=None`, `object.attributes={}`, no label key
- Cache isolation: different `resource_id` values each trigger separate `evaluate()` calls
- Async path coverage

### Documentation
- **CHANGELOG.md**: resource context entry added to `[0.4.0]`
- **README.md**: new "Resource Context (ABAC)" §3 with static + resolver examples; `object` added to policy context schema
- **LEARNINGS.md**: compliance matrix updated (F-IC-01→F-IC-05 fully satisfied); T-07 test pattern added

## Test results
```
183 passed, 0 failed
```

## Spec compliance
| Requirement | Status |
|---|---|
| F-IC-01 — `resource_id` in policy context as `object.id` | ✅ |
| F-IC-02 — `resource_attr` in policy context as `object.attributes` | ✅ |
| F-IC-04 — `resource_attr` serialized in `KestEntry.labels` | ✅ |
| §9.2 — evaluation context `object` subkey | ✅ |