### PR TITLE
feat(core): add output_validators / guardrail hooks to @kest_verified (#78)

### DIFF
--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
   SPEC-v0.3.0 §9.2 (F-IC-01, F-IC-02) and serialized into `KestEntry.labels["kest.resource_attr"]`
   for tamper-evident audit (F-IC-04). The policy decision cache key now includes `resource_id` to
   prevent cross-resource ABAC cache collisions.
+- **Output Validators / Guardrail Hooks** (Issue #78): Added `output_validators` parameter to
+  `@kest_verified` accepting a list of `OutputValidator` instances. Validators are run after
+  function execution; any `OutputValidationError` adds the taint `"output_validation_failed"` to
+  the audit entry and re-raises (the result is NOT returned to the caller). Built-in validators:
+  - `MaxLengthValidator(max_chars)` — rejects outputs whose `str()` exceeds `max_chars` characters.
+  - `RegexDenyListValidator(patterns)` — rejects outputs matching any regex in the deny-list.
 - **Context Accessor Functions** (F-CP-06): Implemented the five public context accessor functions required by SPEC-v0.3.0 §2.8:
   - `get_current_user()` — reads `kest.user` from OTel Baggage
   - `get_current_agent()` — reads `kest.agent` from OTel Baggage

--- a/libs/kest-core/python/README.md
+++ b/libs/kest-core/python/README.md
@@ -169,7 +169,45 @@ def read_document_dynamic(doc_id: str) -> dict:
 
 Resolved values are forwarded to the policy engine as `object.id` / `object.attributes` per SPEC §9.2 and serialized into `KestEntry.labels["kest.resource_attr"]` for tamper-evident audit.
 
-### 4. Policy Validation
+### 4. Output Validators (Guardrails)
+
+Protect against prompt injection artifacts and data leaks by validating function return values
+before they reach the caller. If validation fails, the result is **not returned** and a
+`"output_validation_failed"` taint is recorded in the audit chain.
+
+```python
+from kest.core import (
+    kest_verified,
+    MaxLengthValidator,
+    RegexDenyListValidator,
+)
+
+@kest_verified(
+    policy="summarize",
+    output_validators=[
+        MaxLengthValidator(max_chars=5000),
+        RegexDenyListValidator(patterns=[
+            r"\b\d{3}-\d{2}-\d{4}\b",  # SSN
+            r"CONFIDENTIAL",
+        ]),
+    ],
+)
+def summarize_document(doc_id: str) -> str:
+    ...
+```
+
+You can implement custom validators by subclassing `OutputValidator`:
+
+```python
+from kest.core import OutputValidator, OutputValidationError
+
+class NoBinaryValidator(OutputValidator):
+    def validate(self, output) -> None:
+        if "\x00" in str(output):
+            raise OutputValidationError("Null byte detected in output")
+```
+
+### 5. Policy Validation
 To prevent faulty configurations, Kest provides static AST syntax validations that can proactively check LLM-generated or static policies before deploying them:
 
 ```python

--- a/libs/kest-core/python/src/kest/core/__init__.py
+++ b/libs/kest-core/python/src/kest/core/__init__.py
@@ -40,6 +40,12 @@ from kest.core.framework.ext import (  # noqa: E402
     KestIdentityMiddleware,
     KestMiddleware,
 )
+from kest.core.framework.validators import (  # noqa: E402
+    MaxLengthValidator,
+    OutputValidationError,
+    OutputValidator,
+    RegexDenyListValidator,
+)
 from kest.core.identity import (  # noqa: E402
     AWSWorkloadIdentity,
     BedrockAgentIdentity,
@@ -165,4 +171,9 @@ __all__ = [
     "get_current_task",
     "get_current_jwt",
     "get_current_passport",
+    # Output Validators (Issue #78)
+    "OutputValidator",
+    "OutputValidationError",
+    "MaxLengthValidator",
+    "RegexDenyListValidator",
 ]

--- a/libs/kest-core/python/src/kest/core/framework/decorators.py
+++ b/libs/kest-core/python/src/kest/core/framework/decorators.py
@@ -16,6 +16,7 @@ from opentelemetry import baggage, trace
 from kest.core import KestEntry, sign_entry
 from kest.core.engines.engine import PolicyEngine
 from kest.core.framework.context import get_current_jwt
+from kest.core.framework.validators import OutputValidationError, OutputValidator
 from kest.core.identity import IdentityProvider
 from kest.core.models.passport import (
     ORIGIN_TRUST_MAP,
@@ -459,6 +460,7 @@ def _execute_core_post_auth(
     removed_taints,
     mapped_labels,
     resource_attr: Optional[dict] = None,
+    extra_taints: Optional[List[str]] = None,
 ):
     span = state["span"]
     labels = {"principal": state["principal"]}
@@ -493,9 +495,9 @@ def _execute_core_post_auth(
         labels=labels,
         added_taints=added_taints or [],
         removed_taints=removed_taints or [],
-        taints=list(state["current_accumulated"])
+        taints=list(state["current_accumulated"]) + (extra_taints or [])
         if state["current_accumulated"]
-        else [],
+        else (extra_taints or []),
         policy_context={
             "enterprise_policies": get_active_enterprise_policies(),
             "platform_policies": [],
@@ -539,6 +541,7 @@ def kest_verified(
     context_map: Optional[dict] = None,
     resource_id: Optional[Union[str, Callable]] = None,
     resource_attr: Optional[Union[dict, Callable]] = None,
+    output_validators: Optional[List[OutputValidator]] = None,
 ):
     """
     Decorator that wraps a function with Kest zero-trust policy enforcement.
@@ -561,6 +564,12 @@ def kest_verified(
             callable (resolver) that receives (*args, **kwargs) and returns a dict.
             Forwarded as ``object.attributes`` in the policy context and serialized
             into ``KestEntry.labels["kest.resource_attr"]`` (F-IC-01, F-IC-04).
+        output_validators: Optional list of :class:`~kest.core.framework.validators.OutputValidator`
+            instances.  Each validator's :meth:`validate` method is called with the
+            function's return value after execution succeeds.  If any validator raises
+            :class:`~kest.core.framework.validators.OutputValidationError`, the taint
+            ``"output_validation_failed"`` is added to the audit entry and the error
+            is re-raised (the result is NOT returned to the caller).
     """
     _raw_policies = [policy] if isinstance(policy, str) else policy
     policies = list(dict.fromkeys(_raw_policies))
@@ -633,7 +642,28 @@ def kest_verified(
                 )
                 token = otel_context.attach(new_ctx)
                 try:
-                    return await func(*args, **kwargs)
+                    result = await func(*args, **kwargs)
+                    # Run output validators (Issue #78)
+                    if output_validators:
+                        for validator in output_validators:
+                            try:
+                                validator.validate(result)
+                            except OutputValidationError:
+                                # Re-sign entry with the failure taint audited
+                                await loop.run_in_executor(
+                                    _get_sign_executor(),
+                                    cv.run,
+                                    _execute_core_post_auth,
+                                    state,
+                                    func.__name__,
+                                    added_taints,
+                                    removed_taints,
+                                    mapped_labels,
+                                    resolved_rattr,
+                                    ["output_validation_failed"],
+                                )
+                                raise
+                    return result
                 finally:
                     otel_context.detach(token)
 
@@ -693,7 +723,25 @@ def kest_verified(
                 )
                 token = otel_context.attach(new_ctx)
                 try:
-                    return func(*args, **kwargs)
+                    result = func(*args, **kwargs)
+                    # Run output validators (Issue #78)
+                    if output_validators:
+                        for validator in output_validators:
+                            try:
+                                validator.validate(result)
+                            except OutputValidationError:
+                                # Re-sign entry with the failure taint audited
+                                _execute_core_post_auth(
+                                    state,
+                                    func.__name__,
+                                    added_taints,
+                                    removed_taints,
+                                    mapped_labels,
+                                    resolved_rattr,
+                                    ["output_validation_failed"],
+                                )
+                                raise
+                    return result
                 finally:
                     otel_context.detach(token)
 

--- a/libs/kest-core/python/src/kest/core/framework/validators.py
+++ b/libs/kest-core/python/src/kest/core/framework/validators.py
@@ -1,0 +1,99 @@
+"""
+Output guardrail validators for @kest_verified (Issue #78).
+
+Spec reference: SPEC-v0.3.0 — Defense-in-Depth Structural Validation.
+
+Provides:
+- OutputValidator: ABC for post-execution output validation hooks.
+- OutputValidationError: exception raised when a validator rejects output.
+- MaxLengthValidator: rejects outputs whose string representation exceeds a character limit.
+- RegexDenyListValidator: rejects outputs matching any of a list of regex patterns.
+"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class OutputValidationError(ValueError):
+    """Raised by an OutputValidator when the decorated function's output fails validation.
+
+    Caught by @kest_verified to add the ``output_validation_failed`` taint to the
+    KestEntry before re-raising, ensuring a tamper-evident audit trail of the failure.
+    """
+
+
+class OutputValidator(ABC):
+    """Abstract base class for post-execution output guardrail validators.
+
+    Subclasses must implement :meth:`validate`.  The method should raise
+    :class:`OutputValidationError` when the output fails the check.  Any other
+    exception type will propagate unmodified (it will NOT trigger the
+    ``output_validation_failed`` taint).
+
+    Example::
+
+        class NoNullBytesValidator(OutputValidator):
+            def validate(self, output: Any) -> None:
+                if "\\x00" in str(output):
+                    raise OutputValidationError("Null byte detected in output")
+    """
+
+    @abstractmethod
+    def validate(self, output: Any) -> None:
+        """Validate *output*.  Raise :class:`OutputValidationError` on failure.
+
+        Args:
+            output: The raw return value of the decorated function.
+        """
+
+
+class MaxLengthValidator(OutputValidator):
+    """Rejects outputs whose string representation exceeds *max_chars* characters.
+
+    The output is coerced to ``str`` before measuring length, so this works for
+    any return type (strings, dicts, Pydantic models, etc.).
+
+    Args:
+        max_chars: Maximum allowed length (inclusive).
+
+    Raises:
+        OutputValidationError: When ``len(str(output)) > max_chars``.
+    """
+
+    def __init__(self, max_chars: int) -> None:
+        self._max_chars = max_chars
+
+    def validate(self, output: Any) -> None:
+        length = len(str(output))
+        if length > self._max_chars:
+            raise OutputValidationError(
+                f"Output length {length} exceeds maximum allowed {self._max_chars} characters"
+            )
+
+
+class RegexDenyListValidator(OutputValidator):
+    """Rejects outputs matching any of the provided regex *patterns*.
+
+    The output is coerced to ``str`` before matching.  Uses :func:`re.search`
+    so patterns match anywhere in the string (not just at the start).
+
+    Args:
+        patterns: List of regex pattern strings.  Any match causes rejection.
+
+    Raises:
+        OutputValidationError: When any pattern matches the output.
+    """
+
+    def __init__(self, patterns: list[str]) -> None:
+        self._compiled = [(p, re.compile(p)) for p in patterns]
+
+    def validate(self, output: Any) -> None:
+        text = str(output)
+        for raw_pattern, compiled in self._compiled:
+            if compiled.search(text):
+                raise OutputValidationError(
+                    f"Output matched deny-list pattern: {raw_pattern!r}"
+                )

--- a/libs/kest-core/python/src/kest/core/output_validators_test.py
+++ b/libs/kest-core/python/src/kest/core/output_validators_test.py
@@ -1,0 +1,315 @@
+"""
+TDD tests for output_validators parameter on @kest_verified (Issue #78).
+
+These tests MUST be written before the implementation and must initially fail (RED).
+
+Coverage:
+- OutputValidator ABC contract
+- MaxLengthValidator (pass / fail)
+- RegexDenyListValidator (pass / fail, multiple patterns)
+- output_validators wired into @kest_verified (sync and async)
+- Validation failure adds taint "output_validation_failed" to KestEntry
+- Validation failure raises (function result not returned to caller)
+- Multiple validators: first failure stops execution
+- No validators provided: function works normally
+"""
+
+import asyncio
+
+import pytest
+
+from kest.core import (
+    MockIdentityProvider,
+    MockPolicyEngine,
+    configure,
+    kest_verified,
+)
+from kest.core.framework.decorators import invalidate_policy_cache
+from kest.core.framework.validators import (
+    MaxLengthValidator,
+    OutputValidationError,
+    OutputValidator,
+    RegexDenyListValidator,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _configure_fresh():
+    configure(
+        engine=MockPolicyEngine(allow_all=True),
+        identity=MockIdentityProvider(),
+        clear=True,
+    )
+    invalidate_policy_cache()
+
+
+# ---------------------------------------------------------------------------
+# OutputValidator ABC
+# ---------------------------------------------------------------------------
+
+
+def test_output_validator_is_abstract():
+    """OutputValidator cannot be instantiated directly — must subclass and implement validate()."""
+    with pytest.raises(TypeError):
+        OutputValidator()  # type: ignore[abstract]
+
+
+def test_custom_validator_can_be_implemented():
+    """A concrete subclass implementing validate() can be instantiated and called."""
+
+    class AlwaysPassValidator(OutputValidator):
+        def validate(self, output) -> None:
+            pass  # never raises
+
+    v = AlwaysPassValidator()
+    v.validate("anything")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# MaxLengthValidator unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_max_length_validator_passes_within_limit():
+    v = MaxLengthValidator(max_chars=10)
+    v.validate("hello")  # 5 chars — should not raise
+
+
+def test_max_length_validator_passes_at_exact_limit():
+    v = MaxLengthValidator(max_chars=5)
+    v.validate("hello")  # exactly 5 — should not raise
+
+
+def test_max_length_validator_fails_when_exceeded():
+    v = MaxLengthValidator(max_chars=3)
+    with pytest.raises(OutputValidationError):
+        v.validate("toolong")
+
+
+def test_max_length_validator_works_on_non_string_converts_to_str():
+    """MaxLengthValidator coerces output to str before measuring length."""
+    v = MaxLengthValidator(max_chars=3)
+    # str({"x": 1}) = "{'x': 1}" — 8 chars, exceeds limit of 3
+    with pytest.raises(OutputValidationError):
+        v.validate({"x": 1})
+
+
+def test_max_length_validator_error_includes_limit():
+    v = MaxLengthValidator(max_chars=3)
+    with pytest.raises(OutputValidationError, match="3"):
+        v.validate("toolong")
+
+
+# ---------------------------------------------------------------------------
+# RegexDenyListValidator unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_regex_deny_list_passes_clean_output():
+    v = RegexDenyListValidator(patterns=[r"\b\d{3}-\d{2}-\d{4}\b"])
+    v.validate("This is a safe response with no SSN.")
+
+
+def test_regex_deny_list_fails_on_matching_pattern():
+    v = RegexDenyListValidator(patterns=[r"\b\d{3}-\d{2}-\d{4}\b"])
+    with pytest.raises(OutputValidationError):
+        v.validate("User SSN is 123-45-6789")
+
+
+def test_regex_deny_list_fails_on_any_of_multiple_patterns():
+    v = RegexDenyListValidator(patterns=[r"CONFIDENTIAL", r"\b\d{3}-\d{2}-\d{4}\b"])
+    with pytest.raises(OutputValidationError):
+        v.validate("CONFIDENTIAL document")
+
+
+def test_regex_deny_list_passes_when_no_patterns_match():
+    v = RegexDenyListValidator(patterns=[r"CONFIDENTIAL", r"\b\d{3}-\d{2}-\d{4}\b"])
+    v.validate("This is public information only.")
+
+
+def test_regex_deny_list_error_includes_pattern():
+    v = RegexDenyListValidator(patterns=[r"CONFIDENTIAL"])
+    with pytest.raises(OutputValidationError, match="CONFIDENTIAL"):
+        v.validate("CONFIDENTIAL data")
+
+
+# ---------------------------------------------------------------------------
+# @kest_verified integration — sync
+# ---------------------------------------------------------------------------
+
+
+def test_output_validators_pass_returns_result():
+    """When validators all pass, the function result is returned normally."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", output_validators=[MaxLengthValidator(max_chars=100)])
+    def op() -> str:
+        return "short result"
+
+    assert op() == "short result"
+
+
+def test_output_validators_fail_raises():
+    """When a validator fails, an error is raised and the result is NOT returned."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", output_validators=[MaxLengthValidator(max_chars=3)])
+    def op() -> str:
+        return "way too long output"
+
+    with pytest.raises(OutputValidationError):
+        op()
+
+
+def test_output_validators_fail_adds_taint_to_entry():
+    """Validation failure must add taint 'output_validation_failed' to the KestEntry."""
+    import kest.core._core as _core_mod
+    import kest.core.framework.decorators as dec_mod
+
+    _configure_fresh()
+    captured_entries = []
+    original_sign = _core_mod.sign_entry
+
+    def capturing_sign(entry, identity):
+        captured_entries.append(entry)
+        return original_sign(entry, identity)
+
+    _core_mod.sign_entry = capturing_sign
+    dec_mod.sign_entry = capturing_sign
+
+    try:
+
+        @kest_verified(
+            policy="test", output_validators=[MaxLengthValidator(max_chars=3)]
+        )
+        def op():
+            return "this is too long"
+
+        with pytest.raises(OutputValidationError):
+            op()
+    finally:
+        _core_mod.sign_entry = original_sign
+        dec_mod.sign_entry = original_sign
+
+    assert len(captured_entries) >= 2, (
+        "Expected at least 2 sign calls (normal + failure re-sign)"
+    )
+    last_entry = captured_entries[-1]
+    assert "output_validation_failed" in last_entry.taints
+
+
+def test_output_validators_no_taint_on_success():
+    """Successful validation must NOT add 'output_validation_failed' taint."""
+    import kest.core._core as _core_mod
+    import kest.core.framework.decorators as dec_mod
+
+    _configure_fresh()
+    captured_entries = []
+    original_sign = _core_mod.sign_entry
+
+    def capturing_sign(entry, identity):
+        captured_entries.append(entry)
+        return original_sign(entry, identity)
+
+    _core_mod.sign_entry = capturing_sign
+    dec_mod.sign_entry = capturing_sign
+
+    try:
+
+        @kest_verified(
+            policy="test", output_validators=[MaxLengthValidator(max_chars=1000)]
+        )
+        def op():
+            return "fine"
+
+        op()
+    finally:
+        _core_mod.sign_entry = original_sign
+        dec_mod.sign_entry = original_sign
+
+    assert len(captured_entries) >= 1
+    entry = captured_entries[0]
+    assert "output_validation_failed" not in entry.taints
+
+
+def test_multiple_validators_first_failure_raises():
+    """First failing validator raises immediately; subsequent validators are not run."""
+    _configure_fresh()
+    called = []
+
+    class TrackingValidator(OutputValidator):
+        def __init__(self, name):
+            self._name = name
+
+        def validate(self, output) -> None:
+            called.append(self._name)
+
+    @kest_verified(
+        policy="test",
+        output_validators=[
+            MaxLengthValidator(max_chars=3),  # fails first
+            TrackingValidator("second"),
+        ],
+    )
+    def op():
+        return "toolong"
+
+    with pytest.raises(OutputValidationError):
+        op()
+
+    assert "second" not in called
+
+
+def test_no_validators_returns_result():
+    """With output_validators=None (default), function works normally."""
+    _configure_fresh()
+
+    @kest_verified(policy="test")
+    def op():
+        return 42
+
+    assert op() == 42
+
+
+# ---------------------------------------------------------------------------
+# @kest_verified integration — async
+# ---------------------------------------------------------------------------
+
+
+def test_async_output_validators_pass():
+    _configure_fresh()
+
+    @kest_verified(policy="test", output_validators=[MaxLengthValidator(max_chars=100)])
+    async def async_op():
+        return "ok"
+
+    assert asyncio.run(async_op()) == "ok"
+
+
+def test_async_output_validators_fail_raises():
+    _configure_fresh()
+
+    @kest_verified(policy="test", output_validators=[MaxLengthValidator(max_chars=1)])
+    async def async_op():
+        return "too long response"
+
+    with pytest.raises(OutputValidationError):
+        asyncio.run(async_op())
+
+
+# ---------------------------------------------------------------------------
+# Public API export
+# ---------------------------------------------------------------------------
+
+
+def test_validators_importable_from_kest_core():
+    """OutputValidator, MaxLengthValidator, RegexDenyListValidator must be importable from kest.core."""
+    from kest.core import (  # noqa: F401
+        MaxLengthValidator,
+        OutputValidationError,
+        OutputValidator,
+        RegexDenyListValidator,
+    )


### PR DESCRIPTION
## Summary

Implements [Issue #78](https://github.com/eterna2/kest/issues/78) — adds post-execution output validation hooks to `@kest_verified` for AI guardrail checks on function return values.

## Changes

### `kest/core/framework/validators.py` [NEW]
- `OutputValidator` — ABC with abstract `validate(output) -> None` (raises `OutputValidationError` on failure)
- `OutputValidationError` — exception type for failed validation (subclasses `ValueError`)
- `MaxLengthValidator(max_chars)` — rejects outputs whose `str()` exceeds the character limit
- `RegexDenyListValidator(patterns)` — rejects outputs matching any pattern in the deny-list

### `decorators.py`
- Add `output_validators: Optional[List[OutputValidator]]` parameter to `kest_verified()`
- After the function executes, iterate validators; on first `OutputValidationError`:
  - Re-sign the `KestEntry` with `extra_taints=["output_validation_failed"]` for tamper-evident audit
  - Re-raise the error (result is NOT returned to the caller)
- Add `extra_taints` param to `_execute_core_post_auth()` — appended to the entry's taint list

### `kest/core/__init__.py`
- Export `OutputValidator`, `OutputValidationError`, `MaxLengthValidator`, `RegexDenyListValidator` from the public `kest.core` API

### Tests (`output_validators_test.py`) — TDD
21 new unit tests written **before** implementation (RED → GREEN):
- `OutputValidator` ABC cannot be instantiated directly
- `MaxLengthValidator`: pass/fail/exactly-at-limit/non-string coercion/error message
- `RegexDenyListValidator`: pass/fail single pattern/fail multiple patterns/error message
- `@kest_verified` sync: validators pass → result returned; validators fail → `OutputValidationError` raised
- Taint assertion: failure re-signs entry with `output_validation_failed` taint
- No taint on success
- Multiple validators: first failure stops remaining validators
- No validators: function works normally
- `@kest_verified` async: pass/fail paths
- `kest.core` public API importability

### Documentation
- **CHANGELOG.md**: added output validators entry to `[0.4.0]`
- **README.md**: new §4 "Output Validators (Guardrails)" with built-in and custom examples

## Test results
```
204 passed, 0 failed
```

## Acceptance criteria
| Criterion | Status |
|---|---|
| `OutputValidator` ABC defined | ✅ |
| `output_validators` parameter on `@kest_verified` | ✅ |
| At least 2 built-in validators (`MaxLengthValidator`, `RegexDenyListValidator`) | ✅ |
| Validation failure produces auditable taint `output_validation_failed` | ✅ |
| Unit tests for pass and fail scenarios | ✅ (21 tests) |