### PR TITLE
feat(core): classification-based automatic taint tagging (#80)

### DIFF
--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -13,6 +13,16 @@ All notable changes to this project will be documented in this file.
   SPEC-v0.3.0 §9.2 (F-IC-01, F-IC-02) and serialized into `KestEntry.labels["kest.resource_attr"]`
   for tamper-evident audit (F-IC-04). The policy decision cache key now includes `resource_id` to
   prevent cross-resource ABAC cache collisions.
+- **Classification-based Automatic Taint Tagging** (Issue #80): Added `classification` parameter
+  to `@kest_verified` (default `"system"`, matching the existing behaviour). When a classification
+  is mapped in the active `CLASSIFICATION_TAINT_MAP`, the corresponding taints are automatically
+  merged into the decorated function's `KestEntry` without any manual `added_taints` configuration:
+  - `"data"` → `"contains_data"`
+  - `"critic"` → `"requires_review"`
+  - `"sanitizer"` → `"sanitized"`
+  The map is fully configurable via `configure(classification_taint_map=…)` and resets to
+  defaults on `configure(clear=True)`. Auto-taints respect `removed_taints` (an auto-taint that
+  also appears in `removed_taints` is suppressed).
 - **Output Validators / Guardrail Hooks** (Issue #78): Added `output_validators` parameter to
   `@kest_verified` accepting a list of `OutputValidator` instances. Validators are run after
   function execution; any `OutputValidationError` adds the taint `"output_validation_failed"` to

--- a/libs/kest-core/python/README.md
+++ b/libs/kest-core/python/README.md
@@ -169,7 +169,50 @@ def read_document_dynamic(doc_id: str) -> dict:
 
 Resolved values are forwarded to the policy engine as `object.id` / `object.attributes` per SPEC §9.2 and serialized into `KestEntry.labels["kest.resource_attr"]` for tamper-evident audit.
 
-### 4. Output Validators (Guardrails)
+
+### 4. Classification-Based Automatic Taint Tagging
+
+Assign a **data classification** label to each `@kest_verified` function and let Kest automatically
+apply the relevant taints — no more manual `added_taints` boilerplate.
+
+```python
+from kest.core import kest_verified
+
+@kest_verified(policy="fetch_records", classification="data")
+def fetch_user_records(user_id: str) -> list:
+    ...
+# KestEntry.taints automatically includes "contains_data"
+
+@kest_verified(policy="review_output", classification="critic")
+def review_agent_output(output: str) -> str:
+    ...
+# KestEntry.taints automatically includes "requires_review"
+```
+
+**Default classification → taint map:**
+| Classification | Auto-taint |
+|---|---|
+| `"data"` | `"contains_data"` |
+| `"critic"` | `"requires_review"` |
+| `"sanitizer"` | `"sanitized"` |
+| `"system"` *(default)* | *(none)* |
+
+The map is fully configurable at startup and resets to defaults after `configure(clear=True)`:
+
+```python
+from kest.core import configure
+
+configure(
+    classification_taint_map={
+        "data": ["pii_detected", "needs_encryption"],
+        "agent": ["agent_output"],
+    }
+)
+```
+
+Auto-taints are **suppressed** if the same taint also appears in `removed_taints`.
+
+### 5. Output Validators (Guardrails)
 
 Protect against prompt injection artifacts and data leaks by validating function return values
 before they reach the caller. If validation fails, the result is **not returned** and a

--- a/libs/kest-core/python/src/kest/core/__init__.py
+++ b/libs/kest-core/python/src/kest/core/__init__.py
@@ -73,6 +73,9 @@ _active_identity: IdentityProvider | None = None
 _active_cache: CacheProvider | None = None
 _active_enterprise_policies: list[str] = []
 _active_deviations: list[Any] = []
+_active_classification_taint_map: dict[str, list[str]] | None = (
+    None  # None = use DEFAULT
+)
 
 
 def configure(
@@ -81,6 +84,7 @@ def configure(
     cache: CacheProvider | None = None,
     enterprise_policies: list[str] | None = None,
     deviations: list[Any] | None = None,
+    classification_taint_map: dict[str, list[str]] | None = None,
     clear: bool = False,
 ):
     """
@@ -96,6 +100,10 @@ def configure(
         cache: (Optional) Cache for policy results and lineage claim-checks.
         enterprise_policies: (Optional) List of policy names enforced at the enterprise level tier.
         deviations: (Optional) List of PolicyDeviations for bypassing baseline policies.
+        classification_taint_map: (Optional) Mapping from classification label to list of taints
+            auto-applied when a function decorated with @kest_verified uses that classification.
+            Overrides the built-in DEFAULT_CLASSIFICATION_TAINT_MAP.  Pass ``None`` (or call
+            ``configure(clear=True)``) to reset to the default map.
         clear: If True, resets all global configurations to None.
     """
     global \
@@ -103,13 +111,15 @@ def configure(
         _active_identity, \
         _active_cache, \
         _active_enterprise_policies, \
-        _active_deviations
+        _active_deviations, \
+        _active_classification_taint_map
     if clear:
         _active_engine = None
         _active_identity = None
         _active_cache = None
         _active_enterprise_policies = []
         _active_deviations = []
+        _active_classification_taint_map = None  # resets to DEFAULT in accessor
 
     if engine:
         _active_engine = engine
@@ -125,6 +135,8 @@ def configure(
         _active_enterprise_policies = enterprise_policies
     if deviations is not None:
         _active_deviations = deviations
+    if classification_taint_map is not None:
+        _active_classification_taint_map = classification_taint_map
 
 
 __all__ = [

--- a/libs/kest-core/python/src/kest/core/classification_taints_test.py
+++ b/libs/kest-core/python/src/kest/core/classification_taints_test.py
@@ -1,0 +1,277 @@
+"""
+TDD tests for classification-based automatic taint tagging (Issue #80).
+
+Coverage:
+- classification param on @kest_verified defaults to "system"
+- CLASSIFICATION_TAINT_MAP defaults (data, critic, sanitizer)
+- Auto-taints merged into signed KestEntry.taints
+- Unknown classification → no auto-taints
+- Manual added_taints + auto-taints are both included
+- configure(classification_taint_map=...) overrides the default map globally
+- configure(clear=True) resets the map to defaults
+- Async path: auto-taints applied correctly
+"""
+
+import asyncio
+
+from kest.core import (
+    MockIdentityProvider,
+    MockPolicyEngine,
+    configure,
+    kest_verified,
+)
+from kest.core.framework.decorators import (
+    DEFAULT_CLASSIFICATION_TAINT_MAP,
+    invalidate_policy_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _configure_fresh(classification_taint_map=None):
+    kwargs = dict(
+        engine=MockPolicyEngine(allow_all=True),
+        identity=MockIdentityProvider(),
+        clear=True,
+    )
+    if classification_taint_map is not None:
+        kwargs["classification_taint_map"] = classification_taint_map
+    configure(**kwargs)
+    invalidate_policy_cache()
+
+
+def _capture_taints(fn):
+    """Call @kest_verified-decorated fn and return the taints from the signed KestEntry."""
+    import kest.core._core as _core_mod
+    import kest.core.framework.decorators as dec_mod
+
+    captured_entries = []
+    original_sign = _core_mod.sign_entry
+
+    def capturing_sign(entry, identity):
+        captured_entries.append(entry)
+        return original_sign(entry, identity)
+
+    _core_mod.sign_entry = capturing_sign
+    dec_mod.sign_entry = capturing_sign
+    try:
+        fn()
+    finally:
+        _core_mod.sign_entry = original_sign
+        dec_mod.sign_entry = original_sign
+
+    assert captured_entries, "Expected at least one sign call"
+    return captured_entries[0].taints
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_CLASSIFICATION_TAINT_MAP
+# ---------------------------------------------------------------------------
+
+
+def test_default_map_is_exported():
+    """DEFAULT_CLASSIFICATION_TAINT_MAP must be importable from kest.core.framework.decorators."""
+    assert isinstance(DEFAULT_CLASSIFICATION_TAINT_MAP, dict)
+
+
+def test_default_map_has_data_entry():
+    assert "data" in DEFAULT_CLASSIFICATION_TAINT_MAP
+    assert "contains_data" in DEFAULT_CLASSIFICATION_TAINT_MAP["data"]
+
+
+def test_default_map_has_critic_entry():
+    assert "critic" in DEFAULT_CLASSIFICATION_TAINT_MAP
+    assert "requires_review" in DEFAULT_CLASSIFICATION_TAINT_MAP["critic"]
+
+
+def test_default_map_has_sanitizer_entry():
+    assert "sanitizer" in DEFAULT_CLASSIFICATION_TAINT_MAP
+    assert "sanitized" in DEFAULT_CLASSIFICATION_TAINT_MAP["sanitizer"]
+
+
+# ---------------------------------------------------------------------------
+# classification param — default behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_default_classification_is_system_no_auto_taints():
+    """Default classification='system' should not add any auto-taints."""
+    _configure_fresh()
+
+    @kest_verified(policy="test")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "contains_data" not in taints
+    assert "requires_review" not in taints
+    assert "sanitized" not in taints
+
+
+def test_classification_system_explicit_no_auto_taints():
+    """Explicitly passing classification='system' also adds no auto-taints."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", classification="system")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "contains_data" not in taints
+
+
+def test_classification_data_adds_contains_data_taint():
+    """classification='data' should auto-add 'contains_data' taint."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", classification="data")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "contains_data" in taints
+
+
+def test_classification_critic_adds_requires_review_taint():
+    """classification='critic' should auto-add 'requires_review' taint."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", classification="critic")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "requires_review" in taints
+
+
+def test_classification_sanitizer_adds_sanitized_taint():
+    """classification='sanitizer' should auto-add 'sanitized' taint."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", classification="sanitizer")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "sanitized" in taints
+
+
+def test_unmapped_classification_adds_no_auto_taints():
+    """A valid classification not in the map silently adds no auto-taints."""
+    _configure_fresh()
+
+    @kest_verified(policy="test", classification="snapshot")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    # 'snapshot' is not in DEFAULT_CLASSIFICATION_TAINT_MAP, so no auto-taints
+    assert "contains_data" not in taints
+    assert "requires_review" not in taints
+
+
+def test_manual_added_taints_and_auto_taints_both_present():
+    """Manually specified added_taints and auto-taints from classification must both appear."""
+    _configure_fresh()
+
+    @kest_verified(
+        policy="test", classification="data", added_taints=["my_custom_taint"]
+    )
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "contains_data" in taints
+    assert "my_custom_taint" in taints
+
+
+# ---------------------------------------------------------------------------
+# configure() override
+# ---------------------------------------------------------------------------
+
+
+def test_configure_overrides_classification_taint_map():
+    """configure(classification_taint_map=...) should replace the active map."""
+    custom_map = {"data": ["pii_detected", "needs_encryption"]}
+    _configure_fresh(classification_taint_map=custom_map)
+
+    @kest_verified(policy="test", classification="data")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "pii_detected" in taints
+    assert "needs_encryption" in taints
+    # Default taint for 'data' should NOT be present since map was replaced
+    assert "contains_data" not in taints
+
+
+def test_configure_clear_resets_to_default_map():
+    """configure(clear=True) should reset the classification_taint_map to defaults."""
+    custom_map = {"data": ["custom_taint_only"]}
+    configure(classification_taint_map=custom_map)
+
+    # Now clear — should revert to defaults
+    _configure_fresh()  # calls configure(clear=True)
+
+    @kest_verified(policy="test", classification="data")
+    def op():
+        return "result"
+
+    taints = _capture_taints(op)
+    assert "contains_data" in taints
+    assert "custom_taint_only" not in taints
+
+
+# ---------------------------------------------------------------------------
+# Async path
+# ---------------------------------------------------------------------------
+
+
+def test_async_classification_data_adds_taint():
+    """Async @kest_verified also applies auto-taints from classification."""
+    import kest.core._core as _core_mod
+    import kest.core.framework.decorators as dec_mod
+
+    _configure_fresh()
+    captured_entries = []
+    original_sign = _core_mod.sign_entry
+
+    def capturing_sign(entry, identity):
+        captured_entries.append(entry)
+        return original_sign(entry, identity)
+
+    _core_mod.sign_entry = capturing_sign
+    dec_mod.sign_entry = capturing_sign
+
+    try:
+
+        @kest_verified(policy="test", classification="data")
+        async def async_op():
+            return "ok"
+
+        asyncio.run(async_op())
+    finally:
+        _core_mod.sign_entry = original_sign
+        dec_mod.sign_entry = original_sign
+
+    assert captured_entries, "Expected at least one sign call"
+    assert "contains_data" in captured_entries[0].taints
+
+
+# ---------------------------------------------------------------------------
+# Public API export
+# ---------------------------------------------------------------------------
+
+
+def test_configure_accepts_classification_taint_map():
+    """configure() must accept classification_taint_map without error."""
+    configure(classification_taint_map={"data": ["test_taint"]})
+    # Reset to defaults for subsequent tests
+    configure(
+        clear=True,
+        engine=MockPolicyEngine(allow_all=True),
+        identity=MockIdentityProvider(),
+    )

--- a/libs/kest-core/python/src/kest/core/framework/decorators.py
+++ b/libs/kest-core/python/src/kest/core/framework/decorators.py
@@ -282,6 +282,29 @@ def get_active_deviations() -> List[Any]:
     return getattr(kest.core, "_active_deviations", [])
 
 
+# ---------------------------------------------------------------------------
+# Classification-based automatic taint tagging (Issue #80)
+# ---------------------------------------------------------------------------
+
+DEFAULT_CLASSIFICATION_TAINT_MAP: dict[str, List[str]] = {
+    "data": ["contains_data"],
+    "critic": ["requires_review"],
+    "sanitizer": ["sanitized"],
+}
+
+
+def get_active_classification_taint_map() -> dict[str, List[str]]:
+    """Return the currently active classification→taint mapping.
+
+    Falls back to :data:`DEFAULT_CLASSIFICATION_TAINT_MAP` if none has been
+    configured via :func:`kest.core.configure`.
+    """
+    import kest.core
+
+    stored = getattr(kest.core, "_active_classification_taint_map", None)
+    return stored if stored is not None else DEFAULT_CLASSIFICATION_TAINT_MAP
+
+
 def _build_resource_context(
     resource_id: Optional[Union[str, Callable]],
     resource_attr: Optional[Union[dict, Callable]],
@@ -453,6 +476,28 @@ def _execute_core_logic(
     }
 
 
+def _compute_accumulated_taints(
+    current_accumulated: set,
+    auto_taints: List[str],
+    removed_taints: Optional[List[str]],
+    extra_taints: Optional[List[str]],
+) -> List[str]:
+    """Compute the final accumulated taint list for a KestEntry.
+
+    Merges inherited taints (*current_accumulated*), classification
+    auto-taints, and optional extra taints (e.g. ``output_validation_failed``).
+    Auto-taints are NOT applied if they appear in *removed_taints*.
+    """
+    accumulated = set(current_accumulated)
+    if auto_taints:
+        for taint in auto_taints:
+            if not removed_taints or taint not in removed_taints:
+                accumulated.add(taint)
+    if extra_taints:
+        accumulated.update(extra_taints)
+    return list(accumulated)
+
+
 def _execute_core_post_auth(
     state,
     func_name,
@@ -464,6 +509,11 @@ def _execute_core_post_auth(
 ):
     span = state["span"]
     labels = {"principal": state["principal"]}
+
+    # Resolve classification auto-taints and merge with added_taints
+    classification = state.get("classification", "system")
+    auto_taints = get_active_classification_taint_map().get(classification, [])
+    effective_added_taints = list(added_taints or []) + auto_taints
     span_ctx = span.get_span_context()
     if span_ctx and span_ctx.is_valid:
         labels["trace_id"] = f"{span_ctx.trace_id:032x}"
@@ -489,15 +539,15 @@ def _execute_core_post_auth(
     entry = KestEntry(
         entry_id=state["entry_id"],
         operation=func_name,
-        classification="system",
+        classification=classification,
         trust_score=state["current_node_trust"],
         parent_ids=state["parent_hashes"],
         labels=labels,
-        added_taints=added_taints or [],
+        added_taints=effective_added_taints,
         removed_taints=removed_taints or [],
-        taints=list(state["current_accumulated"]) + (extra_taints or [])
-        if state["current_accumulated"]
-        else (extra_taints or []),
+        taints=_compute_accumulated_taints(
+            state["current_accumulated"], auto_taints, removed_taints, extra_taints
+        ),
         policy_context={
             "enterprise_policies": get_active_enterprise_policies(),
             "platform_policies": [],
@@ -542,6 +592,7 @@ def kest_verified(
     resource_id: Optional[Union[str, Callable]] = None,
     resource_attr: Optional[Union[dict, Callable]] = None,
     output_validators: Optional[List[OutputValidator]] = None,
+    classification: str = "system",
 ):
     """
     Decorator that wraps a function with Kest zero-trust policy enforcement.
@@ -570,6 +621,11 @@ def kest_verified(
             :class:`~kest.core.framework.validators.OutputValidationError`, the taint
             ``"output_validation_failed"`` is added to the audit entry and the error
             is re-raised (the result is NOT returned to the caller).
+        classification: Data classification label for this operation.  Used for
+            automatic taint tagging via the active ``CLASSIFICATION_TAINT_MAP``.
+            Defaults to ``"system"`` (no auto-taints).  Common values: ``"data"``
+            (adds ``"contains_data"``), ``"critic"`` (adds ``"requires_review"``),
+            ``"sanitizer"`` (adds ``"sanitized"``).
     """
     _raw_policies = [policy] if isinstance(policy, str) else policy
     policies = list(dict.fromkeys(_raw_policies))
@@ -601,6 +657,7 @@ def kest_verified(
                 resolved_resource_id=resolved_rid,
                 resolved_resource_attr=resolved_rattr,
             )
+            state["classification"] = classification
 
             span = state["span"]
             with trace.use_span(span, end_on_exit=True):
@@ -691,6 +748,7 @@ def kest_verified(
                 resolved_resource_id=resolved_rid,
                 resolved_resource_attr=resolved_rattr,
             )
+            state["classification"] = classification
 
             span = state["span"]
             with trace.use_span(span, end_on_exit=True):


### PR DESCRIPTION
## Summary

Implements [Issue #80](https://github.com/eterna2/kest/issues/80) — adds automatic taint tagging based on the `classification` field of a `KestEntry` to reduce developer burden and prevent accidental taint omission.

## Changes

### `decorators.py`
- `DEFAULT_CLASSIFICATION_TAINT_MAP` — built-in classification→taint mapping:
  - `"data"" → `["contains_data"]`
  - `"critic"" → `["requires_review"]`
  - `"sanitizer"" → `["sanitized"]`
- `get_active_classification_taint_map()` — accessor that returns the active map, falling back to `DEFAULT` when `None` (including after `configure(clear=True)`)
- `_compute_accumulated_taints()` — helper that merges inherited taints, auto-taints (respecting `removed_taints` suppression), and extra taints
- `kest_verified(classification="system")` — new parameter, injected into `state` dict for both `sync_wrapper` and `async_wrapper`; used in `_execute_core_post_auth` to merge auto-taints into `effective_added_taints` and accumulated `entry.taints`

### `kest/core/__init__.py`
- `_active_classification_taint_map` global — `None` sentinel = use DEFAULT
- `configure(classification_taint_map=...)` — overrides the active map; `configure(clear=True)` resets to DEFAULT

### `classification_taints_test.py` [NEW] — TDD
15 new unit tests written **before** implementation (RED → GREEN):
- `DEFAULT_CLASSIFICATION_TAINT_MAP` is exported and has the correct defaults
- `classification="system"` (explicit and default) adds no auto-taints  
- `classification="data"" → `contains_data` in `entry.taints`
- `classification="critic"" → `requires_review` in `entry.taints`
- `classification="sanitizer"" → `sanitized` in `entry.taints`
- Unmapped classification (e.g. `"snapshot"`) adds no auto-taints
- Manual `added_taints` + auto-taints both appear in the entry
- `configure(classification_taint_map=...)` replaces the active map
- `configure(clear=True)` resets to defaults
- Async path: auto-taints applied correctly

## Test results
```
219 passed, 0 failed
```

## Acceptance criteria
| Criterion | Status |
|---|---|
| `classification` parameter on `@kest_verified` | ✅ |
| Configurable `CLASSIFICATION_TAINT_MAP` | ✅ |
| Auto-taints merged into the signed `KestEntry` | ✅ |
| Override via `configure()` | ✅ |
| Unit tests | ✅ (15 tests) |