### PR TITLE
feat(kest-core): Opaque Handle & HandleVault Primitives (Issue #79)

### DIFF
--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -45,6 +45,20 @@ All notable changes to this project will be documented in this file.
     implement `detect(reference, output) -> float` and raise `OutputValidationError` when the
     drift score meets or exceeds `threshold`.
   All new symbols are exported from the `kest.core` public API.
+- **Data Vault / Opaque Handle Primitives** (Issue #79): Implemented the `kest.core.vault` package
+  providing foundational building blocks for the zero-trust Template & Hydrate composition flow.
+  Raw sensitive data is sealed into a `HandleVault` and referenced by an `OpaqueHandle` — an opaque
+  pointer that carries only a non-sensitive `safe_view` string safe for LLM context windows:
+  - `OpaqueHandle(id, safe_view, owner_principal, created_at, expires_at, granted_principals)` —
+    frozen dataclass; `id` is prefixed `hdl_<uuid4_hex>`; timestamps are UTC-aware.
+  - `HandleVault(cache=None)` — in-memory vault backed by `CacheProvider` (defaults to `SimpleCache`):
+    - `seal(data, owner_principal, safe_view, ttl_seconds=300, granted_principals=())` → `OpaqueHandle`
+    - `unseal(handle_id, requesting_principal)` → raw data; enforces ACL and TTL (lazy expiry check).
+    - `invalidate(handle_id)` — immediate eviction; idempotent for unknown handles.
+    - `get_safe_view(handle_id)` — ACL-free access to the non-sensitive summary.
+  - `HandleNotFoundError`, `HandleExpiredError`, `HandleAccessDeniedError` — typed error hierarchy.
+  - No external dependencies; pluggable `CacheProvider` backend for future Redis / DynamoDB support.
+  All symbols are exported from the `kest.core` public API.
 
 - **Context Accessor Functions** (F-CP-06): Implemented the five public context accessor functions required by SPEC-v0.3.0 §2.8:
   - `get_current_user()` — reads `kest.user` from OTel Baggage

--- a/libs/kest-core/python/README.md
+++ b/libs/kest-core/python/README.md
@@ -354,7 +354,81 @@ class NoBinaryValidator(OutputValidator):
 
 
 
-### 5. Policy Validation
+
+
+### 5. Data Vault / Opaque Handle
+
+In a zero-trust AI architecture, raw sensitive data should **never** reach the LLM context window.
+The `HandleVault` pattern solves this by storing sensitive payloads in a secure in-memory vault and
+giving the LLM only a non-sensitive `safe_view` string alongside an opaque handle ID. A trusted
+gateway later resolves (unseals) the handle with ACL enforcement.
+
+```python
+from kest.core import HandleVault, OpaqueHandle
+from kest.core.vault.errors import HandleAccessDeniedError, HandleExpiredError
+
+vault = HandleVault()
+
+# 1. Seal: sensitive data never leaves the vault
+handle = vault.seal(
+    data="John Doe, SSN: 123-45-6789",
+    owner_principal="spiffe://example.com/service-a",
+    safe_view="A person record with name and SSN",  # <-- safe for LLM
+    ttl_seconds=300,
+)
+
+# handle.id        -> "hdl_a1b2c3..."     (opaque pointer — safe to pass around)
+# handle.safe_view -> "A person record..."  (non-sensitive — safe for LLM prompts)
+
+# 2. LLM operates on safe_view, returns handle.id in its output
+
+# 3. Gateway unseals with ACL check
+raw = vault.unseal(handle.id, requesting_principal="spiffe://example.com/service-a")
+# raw -> "John Doe, SSN: 123-45-6789"
+```
+
+**Grant additional principals:**
+```python
+handle = vault.seal(
+    data={"secret": "value"},
+    owner_principal="spiffe://example.com/service-a",
+    safe_view="Classified payload",
+    granted_principals=["spiffe://example.com/gateway"],
+)
+vault.unseal(handle.id, requesting_principal="spiffe://example.com/gateway")  # OK
+```
+
+**Error handling:**
+```python
+from kest.core import HandleNotFoundError, HandleExpiredError, HandleAccessDeniedError
+
+try:
+    raw = vault.unseal(handle_id, requesting_principal=caller)
+except HandleExpiredError:
+    ...  # TTL elapsed — data no longer accessible
+except HandleAccessDeniedError:
+    ...  # principal not in ACL
+except HandleNotFoundError:
+    ...  # handle was invalidated or never existed
+```
+
+**Early invalidation** (e.g., after a one-shot use):
+```python
+vault.invalidate(handle.id)
+```
+
+**Custom CacheProvider** (e.g., for Redis-backed vaults in production):
+```python
+from kest.core import HandleVault
+from kest.core.framework.cache import CacheProvider
+
+class RedisCache(CacheProvider):
+    ...
+
+vault = HandleVault(cache=RedisCache())
+```
+
+### 6. Policy Validation
 To prevent faulty configurations, Kest provides static AST syntax validations that can proactively check LLM-generated or static policies before deploying them:
 
 ```python

--- a/libs/kest-core/python/src/kest/core/__init__.py
+++ b/libs/kest-core/python/src/kest/core/__init__.py
@@ -75,6 +75,15 @@ from kest.core.models.passport import (  # noqa: E402
     TrustEvaluator,
     register_origin_trust,
 )
+from kest.core.vault import (  # noqa: E402, F401
+    HandleVault,
+    OpaqueHandle,
+)
+from kest.core.vault.errors import (  # noqa: E402, F401
+    HandleAccessDeniedError,
+    HandleExpiredError,
+    HandleNotFoundError,
+)
 
 _active_engine: PolicyEngine | None = None
 _active_identity: IdentityProvider | None = None

--- a/libs/kest-core/python/src/kest/core/vault/__init__.py
+++ b/libs/kest-core/python/src/kest/core/vault/__init__.py
@@ -1,0 +1,37 @@
+"""
+kest.core.vault — Data Vault / Opaque Handle primitives.
+
+In a zero-trust AI architecture, raw sensitive data should never reach the LLM
+context window. Instead:
+
+1. Sensitive data is sealed into a HandleVault.
+2. The vault returns an OpaqueHandle — an opaque pointer carrying only a
+   non-sensitive ``safe_view`` string.
+3. The LLM operates on safe_views and emits handle IDs in its output.
+4. A trusted gateway later resolves (unseals) the handles with ACL enforcement.
+
+Public API::
+
+    from kest.core.vault import HandleVault, OpaqueHandle
+    from kest.core.vault.errors import (
+        HandleNotFoundError,
+        HandleExpiredError,
+        HandleAccessDeniedError,
+    )
+"""
+
+from kest.core.vault.errors import (
+    HandleAccessDeniedError,
+    HandleExpiredError,
+    HandleNotFoundError,
+)
+from kest.core.vault.handle import OpaqueHandle
+from kest.core.vault.vault import HandleVault
+
+__all__ = [
+    "HandleVault",
+    "OpaqueHandle",
+    "HandleNotFoundError",
+    "HandleExpiredError",
+    "HandleAccessDeniedError",
+]

--- a/libs/kest-core/python/src/kest/core/vault/errors.py
+++ b/libs/kest-core/python/src/kest/core/vault/errors.py
@@ -1,0 +1,17 @@
+"""
+Custom exception types for the HandleVault / OpaqueHandle pattern.
+"""
+
+from __future__ import annotations
+
+
+class HandleNotFoundError(KeyError):
+    """Raised when a handle ID does not exist in the vault (or was invalidated)."""
+
+
+class HandleExpiredError(Exception):
+    """Raised when a handle's TTL has elapsed and the data is no longer accessible."""
+
+
+class HandleAccessDeniedError(PermissionError):
+    """Raised when the requesting principal is not authorised to unseal a handle."""

--- a/libs/kest-core/python/src/kest/core/vault/handle.py
+++ b/libs/kest-core/python/src/kest/core/vault/handle.py
@@ -1,0 +1,36 @@
+"""
+OpaqueHandle dataclass: the opaque pointer returned by HandleVault.seal().
+
+A handle carries only non-sensitive metadata (safe_view) and is safe to
+pass to an LLM context window. The actual sensitive payload is stored in
+the vault and only accessible to authorised principals via HandleVault.unseal().
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class OpaqueHandle:
+    """
+    An immutable pointer to sealed data stored in a HandleVault.
+
+    Attributes:
+        id: Unique handle identifier, prefixed with ``hdl_``.
+        safe_view: A human-readable, non-sensitive summary of the sealed data.
+            Safe to include in LLM prompts or logs.
+        owner_principal: The SPIFFE URI (or any principal string) that owns
+            this handle and may unseal it without additional grants.
+        created_at: UTC timestamp of when the handle was created.
+        expires_at: UTC timestamp after which the handle is considered expired.
+        granted_principals: Additional principals allowed to unseal this handle.
+    """
+
+    id: str
+    safe_view: str
+    owner_principal: str
+    created_at: datetime
+    expires_at: datetime
+    granted_principals: frozenset = field(default_factory=frozenset)

--- a/libs/kest-core/python/src/kest/core/vault/vault.py
+++ b/libs/kest-core/python/src/kest/core/vault/vault.py
@@ -1,0 +1,191 @@
+"""
+HandleVault: in-memory secure store for sensitive data payloads.
+
+Raw sensitive data is sealed into the vault and referenced only by an
+OpaqueHandle (an opaque pointer with a non-sensitive safe_view). The LLM
+operates on safe_views; only authorised principals may call unseal() to
+retrieve the original payload.
+
+Design decisions:
+- Lazy TTL eviction: expiry is checked at access time (no background thread,
+  no external scheduler, no extra dependencies).
+- ACL is enforced strictly on unseal() only. get_safe_view() is ACL-free
+  because the safe_view is intentionally non-sensitive.
+- The cache stores a tuple of (OpaqueHandle, data) to keep metadata and
+  payload co-located under a single key.
+- The backing store is pluggable via the CacheProvider interface, defaulting
+  to SimpleCache (in-memory dict). This allows future Redis / DynamoDB backends.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional
+
+from kest.core.framework.cache import CacheProvider, SimpleCache
+from kest.core.vault.errors import (
+    HandleAccessDeniedError,
+    HandleExpiredError,
+    HandleNotFoundError,
+)
+from kest.core.vault.handle import OpaqueHandle
+
+# Internal sentinel: value stored in cache keyed by handle.id
+_Entry = tuple[OpaqueHandle, Any]
+
+
+class HandleVault:
+    """
+    Secure in-memory vault for sensitive data payloads.
+
+    Example::
+
+        vault = HandleVault()
+        handle = vault.seal(
+            data="John Doe, SSN: 123-45-6789",
+            owner_principal="spiffe://example.com/service-a",
+            safe_view="A person record with name and SSN",
+            ttl_seconds=300,
+        )
+        # handle.safe_view -> "A person record with name and SSN"  (safe for LLM)
+        # handle.id        -> "hdl_a1b2c3..."                      (opaque pointer)
+
+        raw = vault.unseal(handle.id, requesting_principal="spiffe://example.com/service-a")
+    """
+
+    def __init__(self, cache: Optional[CacheProvider] = None) -> None:
+        self._cache: CacheProvider = cache if cache is not None else SimpleCache()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def seal(
+        self,
+        data: Any,
+        owner_principal: str,
+        safe_view: str,
+        ttl_seconds: int = 300,
+        granted_principals: Iterable[str] = (),
+    ) -> OpaqueHandle:
+        """
+        Store *data* in the vault and return an opaque handle.
+
+        Args:
+            data: Any Python object to seal. Only returned to authorised
+                principals via :meth:`unseal`.
+            owner_principal: The principal that owns this handle (may always unseal).
+            safe_view: A non-sensitive human-readable description of *data*.
+                Safe to include in LLM prompts, audit logs, and API responses.
+            ttl_seconds: Lifetime of the handle in seconds (default 300 = 5 min).
+                Pass ``0`` to create an already-expired handle (useful in tests).
+            granted_principals: Additional principals permitted to unseal.
+
+        Returns:
+            A frozen :class:`OpaqueHandle` referencing the sealed data.
+        """
+        now = datetime.now(tz=timezone.utc)
+        handle = OpaqueHandle(
+            id=f"hdl_{uuid.uuid4().hex}",
+            safe_view=safe_view,
+            owner_principal=owner_principal,
+            created_at=now,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+            granted_principals=frozenset(granted_principals),
+        )
+        entry: _Entry = (handle, data)
+        self._cache.set(handle.id, entry)
+        return handle
+
+    def unseal(self, handle_id: str, requesting_principal: str) -> Any:
+        """
+        Retrieve the sealed payload for *handle_id*.
+
+        Checks (in order):
+        1. Handle exists in vault.
+        2. Handle has not expired (lazy TTL check).
+        3. *requesting_principal* is the owner or in ``granted_principals``.
+
+        Args:
+            handle_id: The ``id`` field of a previously returned :class:`OpaqueHandle`.
+            requesting_principal: The principal requesting access.
+
+        Returns:
+            The original *data* passed to :meth:`seal`.
+
+        Raises:
+            HandleNotFoundError: Handle was never created or has been invalidated.
+            HandleExpiredError: Handle's TTL has elapsed.
+            HandleAccessDeniedError: Principal is not authorised.
+        """
+        handle, data = self._get_entry(handle_id)
+        self._check_expiry(handle)
+        self._check_acl(handle, requesting_principal)
+        return data
+
+    def invalidate(self, handle_id: str) -> None:
+        """
+        Immediately remove a handle from the vault before its TTL elapses.
+
+        Idempotent: calling this with an unknown or already-invalidated handle
+        does not raise.
+
+        Args:
+            handle_id: The ``id`` of the handle to invalidate.
+        """
+        # SimpleCache doesn't expose delete; overwrite with None sentinel.
+        # For CacheProvider implementations that support deletion this still works
+        # because None is treated as "not found" in _get_entry.
+        self._cache.set(handle_id, None)
+
+    def get_safe_view(self, handle_id: str) -> str:
+        """
+        Return the non-sensitive ``safe_view`` string without ACL enforcement.
+
+        The safe_view is intentionally non-sensitive (it's designed for LLM consumption),
+        so no principal check is performed here.
+
+        Args:
+            handle_id: The ``id`` of the handle.
+
+        Returns:
+            The ``safe_view`` string.
+
+        Raises:
+            HandleNotFoundError: Handle does not exist or was invalidated.
+            HandleExpiredError: Handle's TTL has elapsed.
+        """
+        handle, _data = self._get_entry(handle_id)
+        self._check_expiry(handle)
+        return handle.safe_view
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_entry(self, handle_id: str) -> _Entry:
+        """Retrieve the raw cache entry or raise HandleNotFoundError."""
+        value = self._cache.get(handle_id)
+        if value is None:
+            raise HandleNotFoundError(handle_id)
+        return value  # type: ignore[return-value]
+
+    @staticmethod
+    def _check_expiry(handle: OpaqueHandle) -> None:
+        """Raise HandleExpiredError if the handle's TTL has elapsed."""
+        now = datetime.now(tz=timezone.utc)
+        if now >= handle.expires_at:
+            raise HandleExpiredError(
+                f"Handle '{handle.id}' expired at {handle.expires_at.isoformat()} UTC."
+            )
+
+    @staticmethod
+    def _check_acl(handle: OpaqueHandle, requesting_principal: str) -> None:
+        """Raise HandleAccessDeniedError if the principal is not authorised."""
+        authorised = {handle.owner_principal} | handle.granted_principals
+        if requesting_principal not in authorised:
+            raise HandleAccessDeniedError(
+                f"Principal '{requesting_principal}' is not authorised to unseal "
+                f"handle '{handle.id}'. Authorised principals: {sorted(authorised)}."
+            )

--- a/libs/kest-core/python/src/kest/core/vault/vault_test.py
+++ b/libs/kest-core/python/src/kest/core/vault/vault_test.py
@@ -1,0 +1,291 @@
+"""
+TDD tests for the Data Vault / Opaque Handle pattern (Issue #79).
+
+Covers:
+- OpaqueHandle dataclass field correctness
+- HandleVault.seal(): unique IDs, correct metadata, TTL
+- HandleVault.unseal(): owner access, granted principals, ACL rejection, expiry
+- HandleVault.invalidate(): immediate invalidation
+- HandleVault.get_safe_view(): ACL-free access, missing handle
+- Custom CacheProvider injection
+- Public API importability from kest.core
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from kest.core.vault import HandleVault, OpaqueHandle
+from kest.core.vault.errors import (
+    HandleAccessDeniedError,
+    HandleExpiredError,
+    HandleNotFoundError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+OWNER = "spiffe://example.com/service-a"
+OTHER = "spiffe://example.com/service-b"
+GRANTED = "spiffe://example.com/service-c"
+
+
+def _fresh_vault() -> HandleVault:
+    return HandleVault()
+
+
+def _seal_simple(vault: HandleVault, ttl: int = 300) -> OpaqueHandle:
+    return vault.seal(
+        data="John Doe, SSN: 123-45-6789",
+        owner_principal=OWNER,
+        safe_view="A person record with name and SSN",
+        ttl_seconds=ttl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpaqueHandle dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_opaque_handle_has_required_fields():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    assert handle.id is not None
+    assert handle.safe_view == "A person record with name and SSN"
+    assert handle.owner_principal == OWNER
+    assert isinstance(handle.created_at, datetime)
+    assert isinstance(handle.expires_at, datetime)
+
+
+def test_opaque_handle_id_has_hdl_prefix():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    assert handle.id.startswith("hdl_")
+
+
+def test_opaque_handle_expires_at_after_created_at():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault, ttl=60)
+    delta = (handle.expires_at - handle.created_at).total_seconds()
+    assert abs(delta - 60) < 1  # within 1 second
+
+
+def test_opaque_handle_is_frozen():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    with pytest.raises((AttributeError, TypeError)):
+        handle.safe_view = "mutated"  # type: ignore[misc]
+
+
+def test_opaque_handle_timestamps_are_utc():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    assert handle.created_at.tzinfo == timezone.utc
+    assert handle.expires_at.tzinfo == timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# HandleVault.seal()
+# ---------------------------------------------------------------------------
+
+
+def test_seal_returns_opaque_handle():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    assert isinstance(handle, OpaqueHandle)
+
+
+def test_seal_generates_unique_ids():
+    vault = _fresh_vault()
+    ids = {_seal_simple(vault).id for _ in range(20)}
+    assert len(ids) == 20
+
+
+def test_seal_stores_data_retrievable_by_unseal():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    result = vault.unseal(handle.id, requesting_principal=OWNER)
+    assert result == "John Doe, SSN: 123-45-6789"
+
+
+def test_seal_stores_arbitrary_data_types():
+    vault = _fresh_vault()
+    payload = {"name": "Alice", "score": 42, "tags": ["vip"]}
+    handle = vault.seal(
+        data=payload,
+        owner_principal=OWNER,
+        safe_view="User profile summary",
+    )
+    assert vault.unseal(handle.id, requesting_principal=OWNER) == payload
+
+
+def test_seal_with_granted_principals():
+    vault = _fresh_vault()
+    handle = vault.seal(
+        data="secret",
+        owner_principal=OWNER,
+        safe_view="summary",
+        granted_principals=[GRANTED],
+    )
+    assert vault.unseal(handle.id, requesting_principal=GRANTED) == "secret"
+
+
+# ---------------------------------------------------------------------------
+# HandleVault.unseal()
+# ---------------------------------------------------------------------------
+
+
+def test_unseal_by_owner_succeeds():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    assert (
+        vault.unseal(handle.id, requesting_principal=OWNER)
+        == "John Doe, SSN: 123-45-6789"
+    )
+
+
+def test_unseal_by_granted_principal_succeeds():
+    vault = _fresh_vault()
+    handle = vault.seal(
+        data="confidential",
+        owner_principal=OWNER,
+        safe_view="summary",
+        granted_principals=[GRANTED],
+    )
+    assert vault.unseal(handle.id, requesting_principal=GRANTED) == "confidential"
+
+
+def test_unseal_by_unauthorised_principal_raises_access_denied():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    with pytest.raises(HandleAccessDeniedError):
+        vault.unseal(handle.id, requesting_principal=OTHER)
+
+
+def test_unseal_expired_handle_raises_handle_expired():
+    vault = _fresh_vault()
+    handle = vault.seal(
+        data="ephemeral",
+        owner_principal=OWNER,
+        safe_view="short-lived data",
+        ttl_seconds=0,  # expires immediately
+    )
+    # Ensure expiry by sleeping a tiny bit
+    time.sleep(0.05)
+    with pytest.raises(HandleExpiredError):
+        vault.unseal(handle.id, requesting_principal=OWNER)
+
+
+def test_unseal_unknown_handle_raises_not_found():
+    vault = _fresh_vault()
+    with pytest.raises(HandleNotFoundError):
+        vault.unseal("hdl_doesnotexist", requesting_principal=OWNER)
+
+
+# ---------------------------------------------------------------------------
+# HandleVault.invalidate()
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_makes_unseal_raise_not_found():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    vault.invalidate(handle.id)
+    with pytest.raises(HandleNotFoundError):
+        vault.unseal(handle.id, requesting_principal=OWNER)
+
+
+def test_invalidate_makes_get_safe_view_raise_not_found():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    vault.invalidate(handle.id)
+    with pytest.raises(HandleNotFoundError):
+        vault.get_safe_view(handle.id)
+
+
+def test_invalidate_unknown_handle_is_idempotent():
+    vault = _fresh_vault()
+    # Should not raise
+    vault.invalidate("hdl_doesnotexist")
+
+
+# ---------------------------------------------------------------------------
+# HandleVault.get_safe_view()
+# ---------------------------------------------------------------------------
+
+
+def test_get_safe_view_returns_safe_view_without_acl():
+    vault = _fresh_vault()
+    handle = _seal_simple(vault)
+    # Any caller can get the safe view — it's intentionally non-sensitive
+    assert vault.get_safe_view(handle.id) == "A person record with name and SSN"
+
+
+def test_get_safe_view_unknown_handle_raises_not_found():
+    vault = _fresh_vault()
+    with pytest.raises(HandleNotFoundError):
+        vault.get_safe_view("hdl_doesnotexist")
+
+
+def test_get_safe_view_expired_handle_raises_not_found_or_expired():
+    vault = _fresh_vault()
+    handle = vault.seal(
+        data="gone",
+        owner_principal=OWNER,
+        safe_view="short-lived",
+        ttl_seconds=0,
+    )
+    time.sleep(0.05)
+    with pytest.raises((HandleNotFoundError, HandleExpiredError)):
+        vault.get_safe_view(handle.id)
+
+
+# ---------------------------------------------------------------------------
+# Custom CacheProvider injection
+# ---------------------------------------------------------------------------
+
+
+def test_handle_vault_accepts_custom_cache_provider():
+    """HandleVault should work with any CacheProvider implementation."""
+    from kest.core.framework.cache import SimpleCache
+
+    cache = SimpleCache()
+    vault = HandleVault(cache=cache)
+    handle = _seal_simple(vault)
+    assert (
+        vault.unseal(handle.id, requesting_principal=OWNER)
+        == "John Doe, SSN: 123-45-6789"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multiple independent vaults don't share state
+# ---------------------------------------------------------------------------
+
+
+def test_separate_vaults_are_isolated():
+    vault_a = HandleVault()
+    vault_b = HandleVault()
+    handle = _seal_simple(vault_a)
+    with pytest.raises(HandleNotFoundError):
+        vault_b.unseal(handle.id, requesting_principal=OWNER)
+
+
+# ---------------------------------------------------------------------------
+# Public API importability from kest.core
+# ---------------------------------------------------------------------------
+
+
+def test_vault_symbols_importable_from_kest_core():
+    from kest.core import (  # noqa: F401
+        HandleAccessDeniedError,
+        HandleExpiredError,
+        HandleNotFoundError,
+        HandleVault,
+        OpaqueHandle,
+    )


### PR DESCRIPTION
## Summary

Implements the foundational Data Vault / Opaque Handle pattern described in the Enterprise AI architecture. This provides the building blocks for the Template & Hydrate composition flow where raw sensitive data must **never** reach the LLM context window.

Closes #79

---

## What's New: `kest.core.vault`

### `OpaqueHandle` (frozen dataclass)
| Field | Type | Description |
|---|---|---|
| `id` | `str` | `"hdl_<uuid4_hex>"` — opaque pointer |
| `safe_view` | `str` | Non-sensitive summary safe for LLM prompts |
| `owner_principal` | `str` | SPIFFE URI or any principal |
| `created_at` | `datetime` | UTC-aware creation timestamp |
| `expires_at` | `datetime` | UTC-aware expiry timestamp |
| `granted_principals` | `frozenset` | Additional ACL principals |

### `HandleVault`
| Method | Description |
|---|---|
| `seal(data, owner_principal, safe_view, ttl_seconds=300, granted_principals=())` | Store data; return OpaqueHandle |
| `unseal(handle_id, requesting_principal)` | ACL + lazy TTL check; return raw data |
| `invalidate(handle_id)` | Immediate eviction; idempotent |
| `get_safe_view(handle_id)` | ACL-free access to the non-sensitive safe_view |

### Error Hierarchy
- `HandleNotFoundError(KeyError)` — handle missing or invalidated
- `HandleExpiredError(Exception)` — TTL elapsed
- `HandleAccessDeniedError(PermissionError)` — principal not in ACL

### Design Notes
- **Lazy TTL eviction**: expiry checked on access; no background threads, no scheduler, no extra dependencies.
- **ACL-free `get_safe_view`**: the safe_view is intentionally non-sensitive, so any caller may retrieve it without authorisation.
- **Pluggable CacheProvider**: defaults to `SimpleCache` (in-memory dict); production deployments can inject a Redis/DynamoDB-backed provider.
- **Zero external dependencies**: pure Python, no new packages required.

## Tests
- 24 new unit tests in `vault_test.py` (TDD: written before implementation)
- **282/282 tests pass** (`moon run kest-core-python:test`)
- **100% coverage** on all vault modules
- Autoformat clean (`moon run kest-core-python:format`)

## Docs
- **README**: new §5 Data Vault / Opaque Handle with seal/unseal/grant/invalidate/error/custom-cache examples
- **CHANGELOG**: added Issue #79 entry under `[0.4.0]`

## Public API Exports (from `kest.core`)
```python
from kest.core import (
    HandleVault, OpaqueHandle,
    HandleNotFoundError, HandleExpiredError, HandleAccessDeniedError,
)
```

## Files Changed
- `libs/kest-core/python/src/kest/core/vault/__init__.py` — new package
- `libs/kest-core/python/src/kest/core/vault/errors.py` — error types
- `libs/kest-core/python/src/kest/core/vault/handle.py` — OpaqueHandle
- `libs/kest-core/python/src/kest/core/vault/vault.py` — HandleVault
- `libs/kest-core/python/src/kest/core/vault/vault_test.py` — TDD tests
- `libs/kest-core/python/src/kest/core/__init__.py` — public API exports
- `libs/kest-core/python/CHANGELOG.md` — updated
- `libs/kest-core/python/README.md` — updated