### PR TITLE
feat(vault): SummarizationProvider — auto-generated safe views for LLM context (#82)

### DIFF
--- a/libs/kest-core/python/CHANGELOG.md
+++ b/libs/kest-core/python/CHANGELOG.md
@@ -53,6 +53,29 @@ All notable changes to this project will be documented in this file.
   > **CI note**: `sandbox_live` tests (E2B, AgentCore) are intentionally excluded from CI to
   > avoid cloud billing. Run locally with credentials — see `SANDBOX.md §8` for instructions.
 
+- **SummarizationProvider — Auto-generated Safe Views** (Issue #82): New
+  `kest.core.vault.summarization` module providing an ABC and three concrete
+  implementations for auto-generating non-sensitive `safe_view` strings from raw
+  data payloads at `HandleVault.seal()` time, eliminating the need for callers
+  to write safe-view strings by hand:
+  - `SafeView(summary, data_type, row_count, schema)` — immutable frozen dataclass;
+    `str(safe_view)` returns the summary text for direct prompt embedding.
+  - `SummarizationProvider` — abstract base class; concrete subclasses implement
+    `summarize(data: Any, context: dict) → SafeView`.
+  - `SchemaBasedSummarizer` — structural / schema introspection: recognises dicts
+    (`"Object with N field(s): …"`), list-of-dicts (`"Tabular data: N row(s); columns: …"`),
+    text strings (`"Text value; N characters."`), and pandas DataFrames via duck-typing
+    (no mandatory `pandas` import — `kest-core` remains lightweight).
+  - `TruncatingSummarizer(max_chars=200)` — first-N-characters safe summary with
+    a `[TRUNCATED]` suffix; safe for any payload type.
+  - `AggregationSummarizer` — computes count, sum, min, max for numeric lists and
+    numeric-valued dicts (`"Numeric sequence: N value(s); sum=…; min=…; max=…."`).
+  - `HandleVault.seal()` gains an optional `summarizer: SummarizationProvider | None`
+    keyword argument. When provided, the generated `SafeView.summary` overwrites any
+    manually passed `safe_view`; the `context` dict is forwarded to the provider for
+    future extensibility.
+  - All symbols exported from `kest.core.vault` and hoisted into `kest.core`.
+
 - **Template & Hydrate engine** (Issue #83): New `TemplateParser`, `TemplateEngine`,
   and `HydrationError` in `kest.core.vault` for data-safe LLM report composition
   using **XML handle tags**:

--- a/libs/kest-core/python/README.md
+++ b/libs/kest-core/python/README.md
@@ -723,6 +723,137 @@ except HydrationError as exc:
     # hdl_a1b2…: HandleAccessDeniedError — Principal 'spiffe://untrusted' is not authorised…
 ```
 
+#### 5g. SummarizationProvider — Auto-generated Safe Views (Issue #82)
+
+Instead of writing `safe_view` strings by hand, attach a `SummarizationProvider` to
+`vault.seal()` and let Kest generate a non-sensitive description automatically. The
+generated summary is stored on the `OpaqueHandle` and is safe for LLM prompts without
+ever exposing raw records or PII.
+
+**Basic usage — auto-generate `safe_view` on seal:**
+
+```python
+from kest.core import HandleVault
+from kest.core.vault.summarization import SchemaBasedSummarizer
+
+vault = HandleVault()
+summarizer = SchemaBasedSummarizer()
+
+data = [
+    {"id": 1, "amount": 100.0, "date": "2025-01-01"},
+    {"id": 2, "amount": 250.0, "date": "2025-01-02"},
+]
+
+handle = vault.seal(
+    data=data,
+    owner_principal="spiffe://example.com/data-service",
+    summarizer=summarizer,
+    # safe_view is auto-generated; no need to write it manually
+)
+print(handle.safe_view)
+# → "Tabular data: 2 row(s); columns: id, amount, date."
+```
+
+The `summarizer` always wins — any manually provided `safe_view` is overridden.
+To use both, omit `summarizer` and set `safe_view` explicitly.
+
+**Bundled implementations:**
+
+| Class | Best for | Output example |
+|---|---|---|
+| `SchemaBasedSummarizer` | Dicts, list-of-dicts, DataFrames | `"Tabular data: 5 row(s); columns: id, amount, date."` |
+| `TruncatingSummarizer` | Raw strings, unknown payloads | `"John Doe, SSN: 123-[TRUNCATED]"` |
+| `AggregationSummarizer` | Numeric lists or dicts | `"Numeric sequence: 5 value(s); sum=150; min=10; max=50."` |
+
+**`SchemaBasedSummarizer`** — structural / schema introspection:
+
+```python
+from kest.core.vault.summarization import SchemaBasedSummarizer, SafeView
+
+s = SchemaBasedSummarizer()
+
+s.summarize({"name": "Alice", "age": 30}, {})
+# SafeView(summary="Object with 2 field(s): name, age.", data_type="object", ...)
+
+s.summarize("some raw text", {})
+# SafeView(summary="Text value; 13 characters.", data_type="text")
+
+# pandas DataFrames work via duck-typing — no pandas import required by kest-core
+import pandas as pd
+df = pd.DataFrame({"id": [1, 2], "amount": [100.0, 200.0]})
+s.summarize(df, {})
+# SafeView(summary="DataFrame: 2 row(s) × 2 column(s); columns: id, amount.", ...)
+```
+
+**`TruncatingSummarizer`** — first N characters with `[TRUNCATED]` marker:
+
+```python
+from kest.core.vault.summarization import TruncatingSummarizer
+
+s = TruncatingSummarizer(max_chars=50)
+s.summarize("A very long sensitive text that goes on and on...", {})
+# SafeView(summary="A very long sensitive text that goes on and on [TRUNCATED]", ...)
+```
+
+**`AggregationSummarizer`** — count, sum, min, max:
+
+```python
+from kest.core.vault.summarization import AggregationSummarizer
+
+s = AggregationSummarizer()
+
+s.summarize([10, 20, 30, 40, 50], {})
+# SafeView(summary="Numeric sequence: 5 value(s); sum=150; min=10; max=50.", ...)
+
+s.summarize({"revenue": 1000, "cost": 400, "profit": 600}, {})
+# SafeView(summary="Key-value map: 3 numeric field(s); sum=2000; min=400; max=1000. ...", ...)
+```
+
+**Custom summarizer:**
+
+Implement `SummarizationProvider` to build domain-specific summaries:
+
+```python
+from kest.core.vault.summarization import SummarizationProvider, SafeView
+from typing import Any
+
+class ClinicalDataSummarizer(SummarizationProvider):
+    def summarize(self, data: Any, context: dict) -> SafeView:
+        records = data if isinstance(data, list) else [data]
+        return SafeView(
+            summary=f"Clinical dataset: {len(records)} patient record(s). "
+                    "Contains PHI — access restricted.",
+            data_type="tabular",
+            row_count=len(records),
+        )
+
+vault = HandleVault()
+handle = vault.seal(
+    data=patient_records,
+    owner_principal="spiffe://example.com/ehr-service",
+    summarizer=ClinicalDataSummarizer(),
+)
+# handle.safe_view → "Clinical dataset: 42 patient record(s). Contains PHI — access restricted."
+```
+
+**`SafeView` dataclass:**
+
+The return type of every summarizer. `str(safe_view)` returns the summary text,
+making it easy to embed directly in prompts or log messages.
+
+```python
+from kest.core.vault.summarization import SafeView
+
+sv = SafeView(
+    summary="5,000 transactions; Total: $1.2M",
+    data_type="tabular",
+    row_count=5000,
+    schema={"id": "int", "amount": "float", "date": "datetime"},
+)
+print(str(sv))   # "5,000 transactions; Total: $1.2M"
+print(sv.schema) # {"id": "int", "amount": "float", "date": "datetime"}
+```
+
 ### 6. Policy Validation
 To prevent faulty configurations, Kest provides static AST syntax validations that can proactively check LLM-generated or static policies before deploying them:
 

--- a/libs/kest-core/python/src/kest/core/__init__.py
+++ b/libs/kest-core/python/src/kest/core/__init__.py
@@ -105,6 +105,13 @@ from kest.core.vault.server import (  # noqa: E402, F401
     VaultRPCServer,
     VaultSocketServer,
 )
+from kest.core.vault.summarization import (  # noqa: E402, F401
+    AggregationSummarizer,
+    SafeView,
+    SchemaBasedSummarizer,
+    SummarizationProvider,
+    TruncatingSummarizer,
+)
 from kest.core.vault.template import (  # noqa: E402, F401
     HydrationError,
     TemplateEngine,
@@ -288,6 +295,12 @@ __all__ = [
     "TemplateParser",
     "TemplateEngine",
     "HydrationError",
+    # Summarization — safe data views for LLM context (Issue #82)
+    "SafeView",
+    "SummarizationProvider",
+    "SchemaBasedSummarizer",
+    "TruncatingSummarizer",
+    "AggregationSummarizer",
     # FastAPI integration (kest[fastapi]) — available only if extras installed
     "VaultRouter",
     "VaultDependency",

--- a/libs/kest-core/python/src/kest/core/vault/__init__.py
+++ b/libs/kest-core/python/src/kest/core/vault/__init__.py
@@ -37,6 +37,13 @@ from kest.core.vault.errors import (
     HandleNotFoundError,
 )
 from kest.core.vault.handle import OpaqueHandle
+from kest.core.vault.summarization import (
+    AggregationSummarizer,
+    SafeView,
+    SchemaBasedSummarizer,
+    SummarizationProvider,
+    TruncatingSummarizer,
+)
 from kest.core.vault.template import HydrationError, TemplateEngine, TemplateParser
 from kest.core.vault.vault import HandleVault
 
@@ -62,4 +69,10 @@ __all__ = [
     "TemplateParser",
     "TemplateEngine",
     "HydrationError",
+    # Summarization
+    "SafeView",
+    "SummarizationProvider",
+    "SchemaBasedSummarizer",
+    "TruncatingSummarizer",
+    "AggregationSummarizer",
 ]

--- a/libs/kest-core/python/src/kest/core/vault/summarization.py
+++ b/libs/kest-core/python/src/kest/core/vault/summarization.py
@@ -1,0 +1,339 @@
+"""
+SummarizationProvider: abstraction for producing non-sensitive safe views of raw data.
+
+When sensitive data is sealed into a HandleVault, the LLM still needs to reason about
+*what* the data represents without seeing individual records or PII. A
+SummarizationProvider generates a SafeView — a metadata-rich, non-sensitive textual
+summary — that is stored on the OpaqueHandle and safe to include in LLM prompts.
+
+Design decisions:
+- ``SafeView`` is an immutable dataclass. Its ``summary`` field is the primary textual
+  description; optional fields (data_type, row_count, schema) carry structured metadata.
+- ``SummarizationProvider`` is a minimal ABC: one required method ``summarize(data,
+  context) → SafeView``. The ``context`` dict allows callers to pass hints (e.g.
+  classification, field-level annotations) without coupling the interface to any schema.
+- The three bundled implementations cover the most common summarization patterns:
+  schema introspection, truncation, and statistical aggregation.
+- pandas / numpy are NOT required dependencies. ``SchemaBasedSummarizer`` introspects
+  DataFrames via duck-typing (checks for ``.dtypes`` / ``.shape``) so the vault stays
+  importable without heavyweight ML libraries.
+
+Public API::
+
+    from kest.core.vault.summarization import (
+        SafeView,
+        SummarizationProvider,
+        SchemaBasedSummarizer,
+        TruncatingSummarizer,
+        AggregationSummarizer,
+    )
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# SafeView — immutable result container
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SafeView:
+    """
+    A non-sensitive, human-readable summary of sealed data.
+
+    Designed to be embedded directly in LLM prompts, audit logs, and API
+    responses without exposing raw records or PII.
+
+    Attributes:
+        summary: The primary textual description of the data. Must be safe for
+            LLM consumption (no raw PII, no individual records).
+        data_type: Optional categorical label for the data's structure, e.g.
+            ``"tabular"``, ``"text"``, ``"numeric_sequence"``, ``"object"``,
+            ``"scalar"``, ``"key_value_numeric"``.
+        row_count: Optional count of rows or items in the dataset.
+        schema: Optional mapping of field name → type descriptor, e.g.
+            ``{"id": "int", "amount": "float"}``.
+    """
+
+    summary: str
+    data_type: Optional[str] = field(default=None)
+    row_count: Optional[int] = field(default=None)
+    schema: Optional[dict[str, str]] = field(default=None)
+
+    def __str__(self) -> str:
+        """Return the summary text for easy embedding in prompts."""
+        return self.summary
+
+
+# ---------------------------------------------------------------------------
+# SummarizationProvider — abstract base class
+# ---------------------------------------------------------------------------
+
+
+class SummarizationProvider(ABC):
+    """
+    Abstract interface for generating non-sensitive safe views of raw data.
+
+    Implementors receive the raw data object and an optional context dict,
+    and must return a :class:`SafeView` that describes the data without
+    exposing sensitive content.
+
+    Example::
+
+        class MyProvider(SummarizationProvider):
+            def summarize(self, data: Any, context: dict) -> SafeView:
+                return SafeView(summary=f"Object of type {type(data).__name__}")
+    """
+
+    @abstractmethod
+    def summarize(self, data: Any, context: dict) -> SafeView:
+        """
+        Produce a non-sensitive SafeView for *data*.
+
+        Args:
+            data: The raw data to summarize. May be any Python object.
+            context: Caller-supplied hints (e.g. classification tags, field
+                annotations). Implementors MAY use or ignore this dict.
+
+        Returns:
+            A :class:`SafeView` describing *data* without exposing raw content.
+        """
+
+
+# ---------------------------------------------------------------------------
+# SchemaBasedSummarizer — structural / schema introspection
+# ---------------------------------------------------------------------------
+
+
+class SchemaBasedSummarizer(SummarizationProvider):
+    """
+    Summarizes data by describing its structure, schema, and basic statistics.
+
+    Understands the following data shapes:
+    - ``dict``               → ``data_type="object"``; keys and value types in schema.
+    - ``list[dict]``         → ``data_type="tabular"``; column names and types from first row.
+    - ``list`` (empty)       → ``data_type="tabular"``; row_count=0.
+    - ``list`` (non-dict)    → ``data_type="sequence"``; element type from first item.
+    - ``str``                → ``data_type="text"``; character count in summary.
+    - scalar (int/float/bool)→ ``data_type="scalar"``; value in summary.
+    - pandas DataFrame       → ``data_type="tabular"``; uses ``.dtypes`` + ``.shape``.
+    - anything else          → ``data_type="unknown"``.
+
+    pandas is NOT a required dependency. DataFrame support is activated via
+    duck-typing so this class works with or without pandas installed.
+    """
+
+    def summarize(self, data: Any, context: dict) -> SafeView:  # noqa: ARG002
+        # --- pandas DataFrame (duck-typed, no import required) ---
+        if hasattr(data, "dtypes") and hasattr(data, "shape"):
+            return self._summarize_dataframe(data)
+
+        if isinstance(data, dict):
+            return self._summarize_dict(data)
+
+        if isinstance(data, list):
+            return self._summarize_list(data)
+
+        if isinstance(data, str):
+            return SafeView(
+                summary=f"Text value; {len(data)} characters.",
+                data_type="text",
+            )
+
+        if isinstance(data, (int, float, bool)):
+            return SafeView(
+                summary=f"Scalar value of type {type(data).__name__}.",
+                data_type="scalar",
+            )
+
+        return SafeView(
+            summary=f"Data of type '{type(data).__name__}'.",
+            data_type="unknown",
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _summarize_dict(data: dict) -> SafeView:
+        schema = {k: type(v).__name__ for k, v in data.items()}
+        key_list = ", ".join(list(schema.keys())[:10])
+        suffix = "" if len(schema) <= 10 else f" … (+{len(schema) - 10} more)"
+        summary = f"Object with {len(schema)} field(s): {key_list}{suffix}."
+        return SafeView(summary=summary, data_type="object", schema=schema)
+
+    @staticmethod
+    def _summarize_list(data: list) -> SafeView:
+        n = len(data)
+        if n == 0:
+            return SafeView(
+                summary="Empty sequence (0 items).",
+                data_type="tabular",
+                row_count=0,
+            )
+
+        first = data[0]
+        if isinstance(first, dict):
+            # List-of-dicts → tabular
+            schema = {k: type(v).__name__ for k, v in first.items()}
+            col_list = ", ".join(list(schema.keys())[:8])
+            suffix = "" if len(schema) <= 8 else f" … (+{len(schema) - 8} more)"
+            summary = f"Tabular data: {n} row(s); columns: {col_list}{suffix}."
+            return SafeView(
+                summary=summary,
+                data_type="tabular",
+                row_count=n,
+                schema=schema,
+            )
+
+        elem_type = type(first).__name__
+        return SafeView(
+            summary=f"Sequence of {n} {elem_type}(s).",
+            data_type="sequence",
+            row_count=n,
+        )
+
+    @staticmethod
+    def _summarize_dataframe(df: Any) -> SafeView:
+        """Summarize a pandas DataFrame via duck-typing."""
+        rows, cols = df.shape
+        schema = {str(col): str(dtype) for col, dtype in df.dtypes.items()}
+        col_list = ", ".join(list(schema.keys())[:8])
+        suffix = "" if cols <= 8 else f" … (+{cols - 8} more)"
+        summary = (
+            f"DataFrame: {rows} row(s) × {cols} column(s); columns: {col_list}{suffix}."
+        )
+        return SafeView(
+            summary=summary,
+            data_type="tabular",
+            row_count=rows,
+            schema=schema,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TruncatingSummarizer — first-N-chars with [TRUNCATED] marker
+# ---------------------------------------------------------------------------
+
+
+class TruncatingSummarizer(SummarizationProvider):
+    """
+    Returns the first *max_chars* characters of a string representation of *data*.
+
+    If the string representation exceeds *max_chars*, the summary is truncated
+    and suffixed with ``" [TRUNCATED]"`` so consumers know data was elided.
+
+    Args:
+        max_chars: Maximum number of characters before truncation (default: 200).
+    """
+
+    def __init__(self, max_chars: int = 200) -> None:
+        self._max_chars = max_chars
+
+    def summarize(self, data: Any, context: dict) -> SafeView:  # noqa: ARG002
+        text = data if isinstance(data, str) else str(data)
+        if len(text) > self._max_chars:
+            summary = text[: self._max_chars] + " [TRUNCATED]"
+        else:
+            summary = text
+        return SafeView(summary=summary, data_type="text")
+
+
+# ---------------------------------------------------------------------------
+# AggregationSummarizer — count / sum / min / max
+# ---------------------------------------------------------------------------
+
+
+class AggregationSummarizer(SummarizationProvider):
+    """
+    Computes statistical aggregates (count, sum, min, max) for numeric data.
+
+    Understands:
+    - ``list[int | float]``  → ``data_type="numeric_sequence"``
+    - ``dict[str, int | float]`` → ``data_type="key_value_numeric"``
+    - empty sequences        → row_count=0, no arithmetic
+    - non-numeric data       → falls back to a safe type/count summary
+    """
+
+    def summarize(self, data: Any, context: dict) -> SafeView:  # noqa: ARG002
+        if isinstance(data, list):
+            return self._summarize_list(data)
+        if isinstance(data, dict):
+            return self._summarize_dict(data)
+        return SafeView(
+            summary=f"Data of type '{type(data).__name__}'.",
+            data_type="unknown",
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _summarize_list(data: list) -> SafeView:
+        n = len(data)
+        if n == 0:
+            return SafeView(
+                summary="Empty sequence (0 items).",
+                data_type="numeric_sequence",
+                row_count=0,
+            )
+
+        numeric = [
+            v for v in data if isinstance(v, (int, float)) and not isinstance(v, bool)
+        ]
+        if not numeric:
+            return SafeView(
+                summary=f"Sequence of {n} non-numeric item(s) (type: {type(data[0]).__name__}).",
+                data_type="sequence",
+                row_count=n,
+            )
+
+        total = sum(numeric)
+        minimum = min(numeric)
+        maximum = max(numeric)
+        count = len(numeric)
+        summary = (
+            f"Numeric sequence: {count} value(s); "
+            f"sum={total}; min={minimum}; max={maximum}."
+        )
+        return SafeView(
+            summary=summary,
+            data_type="numeric_sequence",
+            row_count=count,
+        )
+
+    @staticmethod
+    def _summarize_dict(data: dict) -> SafeView:
+        numeric = {
+            k: v
+            for k, v in data.items()
+            if isinstance(v, (int, float)) and not isinstance(v, bool)
+        }
+        if not numeric:
+            return SafeView(
+                summary=f"Key-value map with {len(data)} field(s); no numeric values.",
+                data_type="key_value",
+                row_count=len(data),
+            )
+
+        total = sum(numeric.values())
+        minimum = min(numeric.values())
+        maximum = max(numeric.values())
+        key_list = ", ".join(f"{k}={v}" for k, v in list(numeric.items())[:5])
+        suffix = "" if len(numeric) <= 5 else f" … (+{len(numeric) - 5} more)"
+        summary = (
+            f"Key-value map: {len(numeric)} numeric field(s); "
+            f"sum={total}; min={minimum}; max={maximum}. "
+            f"Fields: {key_list}{suffix}."
+        )
+        return SafeView(
+            summary=summary,
+            data_type="key_value_numeric",
+            row_count=len(numeric),
+        )

--- a/libs/kest-core/python/src/kest/core/vault/summarization_test.py
+++ b/libs/kest-core/python/src/kest/core/vault/summarization_test.py
@@ -1,0 +1,317 @@
+"""
+TDD tests for the SummarizationProvider interface and concrete implementations (Issue #82).
+
+Covers:
+- SafeView dataclass: required fields, immutability, optional fields
+- SummarizationProvider ABC: cannot be instantiated directly
+- SchemaBasedSummarizer: dict introspection, pandas DataFrame, list-of-dicts
+- TruncatingSummarizer: truncation at N chars, passthrough for short strings
+- AggregationSummarizer: count/sum/min/max for numeric sequences and dicts
+- HandleVault.seal() auto-summarization when a SummarizationProvider is injected
+- Public API importability from kest.core.vault
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kest.core.vault.summarization import (
+    AggregationSummarizer,
+    SafeView,
+    SchemaBasedSummarizer,
+    SummarizationProvider,
+    TruncatingSummarizer,
+)
+from kest.core.vault.vault import HandleVault
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+OWNER = "spiffe://example.com/service-a"
+
+
+# ---------------------------------------------------------------------------
+# SafeView dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_safe_view_required_fields():
+    sv = SafeView(summary="A table of 5,000 transactions")
+    assert sv.summary == "A table of 5,000 transactions"
+
+
+def test_safe_view_optional_fields_default_none():
+    sv = SafeView(summary="test")
+    assert sv.data_type is None
+    assert sv.row_count is None
+    assert sv.schema is None
+
+
+def test_safe_view_with_all_fields():
+    sv = SafeView(
+        summary="5,000 transactions; Total: $1.2M",
+        data_type="tabular",
+        row_count=5000,
+        schema={"id": "int", "amount": "float", "date": "datetime"},
+    )
+    assert sv.data_type == "tabular"
+    assert sv.row_count == 5000
+    assert sv.schema == {"id": "int", "amount": "float", "date": "datetime"}
+
+
+def test_safe_view_is_frozen():
+    sv = SafeView(summary="immutable")
+    with pytest.raises((AttributeError, TypeError)):
+        sv.summary = "mutated"  # type: ignore[misc]
+
+
+def test_safe_view_str_returns_summary():
+    """str(safe_view) should return the summary text for easy embedding."""
+    sv = SafeView(summary="Q3 total expenditure")
+    assert str(sv) == "Q3 total expenditure"
+
+
+# ---------------------------------------------------------------------------
+# SummarizationProvider ABC
+# ---------------------------------------------------------------------------
+
+
+def test_summarization_provider_is_abstract():
+    """Cannot instantiate the ABC directly."""
+    with pytest.raises(TypeError):
+        SummarizationProvider()  # type: ignore[abstract]
+
+
+def test_summarization_provider_subclass_must_implement_summarize():
+    """A subclass that does not implement summarize() raises TypeError."""
+
+    class BadProvider(SummarizationProvider):
+        pass  # missing summarize()
+
+    with pytest.raises(TypeError):
+        BadProvider()  # type: ignore[abstract]
+
+
+def test_summarization_provider_concrete_subclass_works():
+    class EchoProvider(SummarizationProvider):
+        def summarize(self, data: Any, context: dict) -> SafeView:
+            return SafeView(summary=str(data))
+
+    p = EchoProvider()
+    sv = p.summarize("hello", {})
+    assert sv.summary == "hello"
+
+
+# ---------------------------------------------------------------------------
+# SchemaBasedSummarizer
+# ---------------------------------------------------------------------------
+
+
+def test_schema_based_summarizer_with_dict():
+    s = SchemaBasedSummarizer()
+    data = {"name": "Alice", "age": 30, "active": True}
+    sv = s.summarize(data, {})
+    assert isinstance(sv, SafeView)
+    assert sv.data_type == "object"
+    # Schema keys must appear
+    assert "name" in (sv.schema or {})
+    assert "age" in (sv.schema or {})
+    assert "active" in (sv.schema or {})
+
+
+def test_schema_based_summarizer_with_list_of_dicts():
+    s = SchemaBasedSummarizer()
+    data = [{"id": 1, "val": 10}, {"id": 2, "val": 20}, {"id": 3, "val": 30}]
+    sv = s.summarize(data, {})
+    assert sv.data_type == "tabular"
+    assert sv.row_count == 3
+    schema = sv.schema or {}
+    assert "id" in schema
+    assert "val" in schema
+
+
+def test_schema_based_summarizer_with_empty_list():
+    s = SchemaBasedSummarizer()
+    sv = s.summarize([], {})
+    assert sv.row_count == 0
+    assert "empty" in sv.summary.lower() or sv.row_count == 0
+
+
+def test_schema_based_summarizer_with_string():
+    s = SchemaBasedSummarizer()
+    sv = s.summarize("some raw text", {})
+    assert sv.data_type == "text"
+    assert isinstance(sv.summary, str)
+
+
+def test_schema_based_summarizer_with_int():
+    s = SchemaBasedSummarizer()
+    sv = s.summarize(42, {})
+    assert sv.data_type == "scalar"
+
+
+def test_schema_based_summarizer_passes_context():
+    """The context dict is accepted without error (can be empty or populated)."""
+    s = SchemaBasedSummarizer()
+    sv = s.summarize({"x": 1}, {"hint": "financial"})
+    assert isinstance(sv, SafeView)
+
+
+# ---------------------------------------------------------------------------
+# TruncatingSummarizer
+# ---------------------------------------------------------------------------
+
+
+def test_truncating_summarizer_short_string_passthrough():
+    s = TruncatingSummarizer(max_chars=100)
+    sv = s.summarize("hello world", {})
+    assert sv.summary == "hello world"
+    assert "[TRUNCATED]" not in sv.summary
+
+
+def test_truncating_summarizer_long_string_truncated():
+    s = TruncatingSummarizer(max_chars=10)
+    sv = s.summarize("A" * 50, {})
+    assert "[TRUNCATED]" in sv.summary
+    assert len(sv.summary) <= 10 + len(" [TRUNCATED]")
+
+
+def test_truncating_summarizer_non_string_coerced():
+    s = TruncatingSummarizer(max_chars=20)
+    sv = s.summarize({"key": "value"}, {})
+    assert isinstance(sv.summary, str)
+
+
+def test_truncating_summarizer_default_max_chars():
+    """Default max_chars is 200 (a reasonable default)."""
+    s = TruncatingSummarizer()
+    long_text = "x" * 500
+    sv = s.summarize(long_text, {})
+    assert "[TRUNCATED]" in sv.summary
+
+
+def test_truncating_summarizer_data_type_is_text():
+    s = TruncatingSummarizer(max_chars=100)
+    sv = s.summarize("hi", {})
+    assert sv.data_type == "text"
+
+
+def test_truncating_summarizer_exactly_at_limit():
+    s = TruncatingSummarizer(max_chars=5)
+    sv = s.summarize("12345", {})
+    # Exactly at limit — should NOT be truncated
+    assert "[TRUNCATED]" not in sv.summary
+
+
+# ---------------------------------------------------------------------------
+# AggregationSummarizer
+# ---------------------------------------------------------------------------
+
+
+def test_aggregation_summarizer_list_of_numbers():
+    s = AggregationSummarizer()
+    data = [10, 20, 30, 40, 50]
+    sv = s.summarize(data, {})
+    assert sv.data_type == "numeric_sequence"
+    assert sv.row_count == 5
+    assert "10" in sv.summary  # min
+    assert "50" in sv.summary  # max
+    assert "150" in sv.summary  # sum
+
+
+def test_aggregation_summarizer_list_of_numeric_strings_raises_or_handles():
+    """Non-numeric sequences should still return a valid SafeView."""
+    s = AggregationSummarizer()
+    sv = s.summarize(["a", "b", "c"], {})
+    assert isinstance(sv, SafeView)
+
+
+def test_aggregation_summarizer_dict_of_numeric_values():
+    s = AggregationSummarizer()
+    data = {"revenue": 1000, "cost": 400, "profit": 600}
+    sv = s.summarize(data, {})
+    assert sv.data_type == "key_value_numeric"
+    assert "1000" in sv.summary or "600" in sv.summary
+
+
+def test_aggregation_summarizer_empty_list():
+    s = AggregationSummarizer()
+    sv = s.summarize([], {})
+    assert sv.row_count == 0
+
+
+def test_aggregation_summarizer_non_numeric_dict():
+    s = AggregationSummarizer()
+    sv = s.summarize({"name": "Alice", "city": "Paris"}, {})
+    assert isinstance(sv, SafeView)
+
+
+def test_aggregation_summarizer_single_value():
+    s = AggregationSummarizer()
+    sv = s.summarize([42], {})
+    assert sv.row_count == 1
+    assert "42" in sv.summary
+
+
+# ---------------------------------------------------------------------------
+# HandleVault integration — auto-summarize on seal()
+# ---------------------------------------------------------------------------
+
+
+def test_handle_vault_seal_with_summarizer_sets_safe_view():
+    """When a summarizer is passed to seal(), the safe_view is auto-generated."""
+    summarizer = TruncatingSummarizer(max_chars=50)
+    vault = HandleVault()
+    data = "John Doe, SSN: 123-45-6789"
+    handle = vault.seal(
+        data=data,
+        owner_principal=OWNER,
+        summarizer=summarizer,
+    )
+    # safe_view should be auto-generated from the summarizer
+    assert handle.safe_view is not None
+    assert len(handle.safe_view) > 0
+
+
+def test_handle_vault_seal_summarizer_overrides_explicit_safe_view():
+    """When both safe_view and summarizer are given, summarizer wins."""
+    summarizer = SchemaBasedSummarizer()
+    vault = HandleVault()
+    data = {"name": "Bob", "score": 99}
+    handle = vault.seal(
+        data=data,
+        owner_principal=OWNER,
+        safe_view="manual override",
+        summarizer=summarizer,
+    )
+    # The summarizer's output replaces the manual safe_view
+    assert handle.safe_view != "manual override"
+
+
+def test_handle_vault_seal_without_summarizer_uses_safe_view():
+    """Existing seal() without summarizer still works unchanged."""
+    vault = HandleVault()
+    handle = vault.seal(
+        data="raw payload",
+        owner_principal=OWNER,
+        safe_view="explicit description",
+    )
+    assert handle.safe_view == "explicit description"
+
+
+# ---------------------------------------------------------------------------
+# Public API importability from kest.core.vault
+# ---------------------------------------------------------------------------
+
+
+def test_summarization_symbols_importable_from_vault():
+    from kest.core.vault import (  # noqa: F401
+        AggregationSummarizer,
+        SafeView,
+        SchemaBasedSummarizer,
+        SummarizationProvider,
+        TruncatingSummarizer,
+    )

--- a/libs/kest-core/python/src/kest/core/vault/vault.py
+++ b/libs/kest-core/python/src/kest/core/vault/vault.py
@@ -31,6 +31,7 @@ from kest.core.vault.errors import (
     HandleNotFoundError,
 )
 from kest.core.vault.handle import OpaqueHandle
+from kest.core.vault.summarization import SummarizationProvider
 
 # Internal sentinel: value stored in cache keyed by handle.id.
 # When a codec is active the *data* portion is bytes (encoded payload);
@@ -73,9 +74,10 @@ class HandleVault:
         self,
         data: Any,
         owner_principal: str,
-        safe_view: str,
+        safe_view: str = "",
         ttl_seconds: int = 300,
         granted_principals: Iterable[str] = (),
+        summarizer: Optional[SummarizationProvider] = None,
     ) -> OpaqueHandle:
         """
         Store *data* in the vault and return an opaque handle.
@@ -86,13 +88,21 @@ class HandleVault:
             owner_principal: The principal that owns this handle (may always unseal).
             safe_view: A non-sensitive human-readable description of *data*.
                 Safe to include in LLM prompts, audit logs, and API responses.
+                Ignored (overridden) when *summarizer* is provided.
             ttl_seconds: Lifetime of the handle in seconds (default 300 = 5 min).
                 Pass ``0`` to create an already-expired handle (useful in tests).
             granted_principals: Additional principals permitted to unseal.
+            summarizer: Optional :class:`~kest.core.vault.summarization.SummarizationProvider`.
+                When supplied, it is called with *data* and an empty context dict to
+                auto-generate the ``safe_view``.  The generated summary overrides any
+                value passed as *safe_view*.
 
         Returns:
             A frozen :class:`OpaqueHandle` referencing the sealed data.
         """
+        if summarizer is not None:
+            sv = summarizer.summarize(data, {})
+            safe_view = str(sv)
         now = datetime.now(tz=timezone.utc)
         handle = OpaqueHandle(
             id=f"hdl_{uuid.uuid4().hex}",


### PR DESCRIPTION
## Summary

Implements the `SummarizationProvider` interface in `kest.core.vault` (Issue #82), enabling automatic generation of non-sensitive `safe_view` strings from raw data payloads at `HandleVault.seal()` time. Callers no longer need to write safe-view strings by hand.

## Changes

### New: `kest.core.vault.summarization`

| Symbol | Description |
|---|---|
| `SafeView` | Immutable frozen dataclass; `str(sv)` returns the summary text |
| `SummarizationProvider` | ABC — implement `summarize(data, context) → SafeView` |
| `SchemaBasedSummarizer` | Introspects dicts, list-of-dicts, text, DataFrames (duck-typed) |
| `TruncatingSummarizer` | First-N-characters safe summary with `[TRUNCATED]` suffix |
| `AggregationSummarizer` | count / sum / min / max for numeric lists and dicts |

### Modified: `HandleVault.seal()`

Added optional `summarizer: SummarizationProvider | None` keyword argument. When provided, the generated `SafeView.summary` overwrites any manually supplied `safe_view`.

### Exports

All five symbols are exported from `kest.core.vault` and hoisted into the top-level `kest.core` namespace.

## Usage

```python
from kest.core import HandleVault, SchemaBasedSummarizer

vault = HandleVault()
handle = vault.seal(
    data=[{"id": 1, "amount": 100.0}, {"id": 2, "amount": 250.0}],
    owner_principal="spiffe://example.com/data-service",
    summarizer=SchemaBasedSummarizer(),
)
print(handle.safe_view)
# → "Tabular data: 2 row(s); columns: id, amount."
```

## Test Results

```
446 passed, 19 skipped (sandbox_live excluded from CI by design)
Coverage: 90% overall; summarization.py at 89%
```

## Checklist

- [x] TDD — tests written before implementation
- [x] `ruff format` + `ruff check --fix` applied
- [x] All symbols exported from public API
- [x] README §5g added with usage examples and custom summarizer guide
- [x] CHANGELOG `[Unreleased]` entry added
- [x] 446 unit tests pass
